### PR TITLE
Personal account rework

### DIFF
--- a/.idea/modules/app/VP_Managaer.app.iml
+++ b/.idea/modules/app/VP_Managaer.app.iml
@@ -31,7 +31,9 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../../app">
       <sourceFolder url="file://$MODULE_DIR$/../../../app/build/generated/ap_generated_sources/debug/out" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../app/build/generated/ap_generated_sources/debug/out" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/../../../app/build/generated/res/resValues/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/../../../app/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/../../../app/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/../../../app/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../../../app/src/main/java" isTestSource="false" />

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -4,6 +4,7 @@ import static android.content.ContentValues.TAG;
 import static com.example.vpmanager.views.mainActivity.uniqueID;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -299,6 +300,31 @@ public class PA_ExpandableListDataPump extends Activity {
                 .addOnSuccessListener(aVoid -> Log.d(TAG, "DocumentSnapshot successfully updated!"))
                 .addOnFailureListener(e -> Log.w(TAG, "Error updating document", e));
     }
+
+    public static boolean navigateToStudyCreatorFragment(String currentUserId, String currentStudyId) {
+
+        if(dbStudiesList.size() <= 0)
+        {
+            new Thread(() -> getAllStudies(() -> {       })).start();
+
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        for (Map<String, Object> map : dbStudiesList)
+        {
+            if (Objects.requireNonNull(map.get("creator")).toString().equals(currentUserId) &&
+                    Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId))
+            {
+                    return true;
+            }
+        }
+        return false;
+    }
+
+
 
     public interface FirestoreCallbackDates {
         void onCallback(boolean finished);

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -1,5 +1,6 @@
 package com.example.vpmanager;
 
+import static android.content.ContentValues.TAG;
 import static com.example.vpmanager.views.mainActivity.uniqueID;
 
 import android.app.Activity;
@@ -289,7 +290,15 @@ public class PA_ExpandableListDataPump extends Activity {
         return arrivingDates;
     }
 
+    public static void updateStudyInDataBase(Map<String, Object> updateData, String studyID) {
 
+        db = FirebaseFirestore.getInstance();
+
+        db.collection("studies").document(studyID)
+                .update(updateData)
+                .addOnSuccessListener(aVoid -> Log.d(TAG, "DocumentSnapshot successfully updated!"))
+                .addOnFailureListener(e -> Log.w(TAG, "Error updating document", e));
+    }
 
     public interface FirestoreCallbackDates {
         void onCallback(boolean finished);

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -17,6 +17,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
+import java.lang.reflect.Array;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -25,6 +25,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class PA_ExpandableListDataPump extends Activity {
 
@@ -203,15 +204,17 @@ public class PA_ExpandableListDataPump extends Activity {
             String date = null;
             for (String key : map.keySet()) {
                 if (key.equals("studyId")) {
-                    studyId = map.get(key).toString();
+                    studyId = Objects.requireNonNull(map.get(key)).toString();
                 }
                 if (key.equals("date")) {
-                    date = map.get(key).toString();
+                    date = Objects.requireNonNull(map.get(key)).toString();
                 }
                 if (key.equals("userId")) {
-                    userID = map.get(key).toString();
-                    if (userID == uniqueID) {
-                        saveDate = true;
+                    if(map.get(key) != null) {
+                        userID = map.get(key).toString();
+                        if (userID.equals(uniqueID)) {
+                            saveDate = true;
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -271,7 +271,7 @@ public class PA_ExpandableListDataPump extends Activity {
             String date = studyIdList.get(key);
 
             for (Map<String, Object> map : dbStudiesList) {
-                if (map.get("studyId").toString().equals(key)) {
+                if (map.get("id").toString().equals(key)) {
                     if (map.get("name").toString() != null) {
                         studyName = map.get("name").toString();
                     }
@@ -281,8 +281,8 @@ public class PA_ExpandableListDataPump extends Activity {
             if (studyName != null) {
                 String[] listEntry = new String[3];
                 listEntry[0] = studyName;
-                listEntry[0] = date;
-                listEntry[0] = key;
+                listEntry[1] = date;
+                listEntry[2] = key;
 
                 arrivingDates.add(listEntry);
             }

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -161,7 +161,6 @@ public class PA_ExpandableListDataPump extends Activity {
                 }
             }
         }
-
         EXPANDABLE_LIST_DETAIL.put("Vergangene Studien", passedStudies);
         EXPANDABLE_LIST_DETAIL.put("Geplante Studien", ownStudies);
     }

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -1,147 +1,82 @@
 package com.example.vpmanager;
 
+import static com.example.vpmanager.views.mainActivity.uniqueID;
+
 import android.app.Activity;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.example.vpmanager.views.mainActivity;
 import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class PA_ExpandableListDataPump extends Activity {
 
-    private static FirebaseFirestore db;
-    private static CollectionReference datesRef, studiesRef;
-    private static final HashMap<String, String> STUDY_ID_NAME = new HashMap<>();
-    private static final HashMap<String, String> STUDY_ID_VPS = new HashMap<>();
-    private static final HashMap<String, String> STUDY_ID_DATE = new HashMap<>();
-    private static final HashMap<String, String> OWN_STUDY_ID_NAME = new HashMap<>();
-    private static final HashMap<String, String> OWN_STUDY_ID_VPS = new HashMap<>();
-    private static final HashMap<String, ArrayList<String>> OWN_STUDY_ID_DATES = new HashMap<>();
-    private static final HashMap<String, List<String>> EXPANDABLE_LIST_DETAIL = new HashMap<String, List<String>>();
+    public static FirebaseFirestore db;
+    public static CollectionReference datesRef;
+    public static CollectionReference studiesRef;
+    public static final HashMap<String, List<String>> EXPANDABLE_LIST_DETAIL = new HashMap<>();
 
-    //Parameters
-    //Return Values: Returns a HashMap with test data for the personal account view
-    //this function generates an ArrayList for each category which is displayed in the overview in the personal Account
-    public static HashMap<String, List<String>> getData() {
-        getBookedDates(new FirestoreCallbackDates() {
-            @Override
-            public void onCallback() {
-                getNameAndVPS();
-            }
-        });
-
-        getOwnStudies(new FirestoreCallbackOwnStudy() {
-            @Override
-            public void onCallback() {
-                for (int i = 0; i < OWN_STUDY_ID_NAME.keySet().size(); i++) {
-                    String key = OWN_STUDY_ID_NAME.keySet().toArray(new String[0])[i];
-                    getAllBookedDatesForOwnStudies(key, new FirestoreCallbackBookedDatesOfOwnStudy() {
-                        @Override
-                        public void onCallback() {
-
-                        }
-                    });
-                }
-            }
-        });
-
-        createListEntries();
-        return EXPANDABLE_LIST_DETAIL;
-    }
-
-    private static void createListEntries() {
-        List<String> ownStudies = new ArrayList<>();
-        String[] ownStudyKeys = OWN_STUDY_ID_NAME.keySet().toArray(new String[0]);
-        for (int i = 0; i < OWN_STUDY_ID_NAME.size(); i++) {
-            String StudyName = OWN_STUDY_ID_NAME.get(ownStudyKeys[i]);
-            String StudyVPS = OWN_STUDY_ID_VPS.get(ownStudyKeys[i]);
-            ArrayList<String> dates = OWN_STUDY_ID_DATES.get(ownStudyKeys[i]);
-            if (dates == null) {
-                continue;
-            }
-            for (int k = 0; k < dates.size(); k++) {
-                String StudyDate = dates.get(k);
-                ownStudies.add(StudyName + "," + StudyVPS + "," + StudyDate + "," + ownStudyKeys[i]);
-            }
-        }
-
-        List<String> plannedStudies = new ArrayList<String>();
-        String[] keys = STUDY_ID_DATE.keySet().toArray(new String[0]);
-        for (int i = 0; i < STUDY_ID_DATE.size(); i++) {
-            String StudyName = STUDY_ID_NAME.get(keys[i]);
-            String StudyDate = STUDY_ID_DATE.get(keys[i]);
-            String StudyVPS = STUDY_ID_VPS.get(keys[i]);
-
-            plannedStudies.add(StudyName + "," + StudyVPS + "," + StudyDate + "," + keys[i]);
-        }
-
-        EXPANDABLE_LIST_DETAIL.put("Geplante Studien", plannedStudies);
-        EXPANDABLE_LIST_DETAIL.put("Eigene Studien", ownStudies);
-    }
+    public static final List<Map<String, Object>> dbDatesList = new ArrayList<>();
+    public static final List<Map<String, Object>> dbStudiesList = new ArrayList<>();
 
     //Parameters
     //Return Values:
-    //this function searches for each date where the user id is mentioned for the name and VPS of the study
-    private static void getNameAndVPS() {
-        String[] key = STUDY_ID_DATE.keySet().toArray(new String[0]);
-
-        for (int i = 0; i < STUDY_ID_DATE.size(); i++) {
-            String StudyID = key[i];
-            getStudies(StudyID, new FirestoreCallbackStudy() {
-                @Override
-                public void onCallback() {
-                }
-            });
-        }
-    }
-
-    //Parameters
-    //Return Values: Returns a HashMap with test data for the personal account view
-    //this function searches through all existing dates in the DB for the users ID and adds the matches in a Hashmap. Key is the study and value the date.
-    private static void getBookedDates(FirestoreCallbackDates firestoreCallbackDates) {
-        String uniqueID = mainActivity.uniqueID; //before: homeActivity.uniqueID
+    //this function saves all Dates from DB to list
+    public static void getAllDates(FirestoreCallbackDates firestoreCallbackDates) {
         db = FirebaseFirestore.getInstance();
         datesRef = db.collection("dates");
-
-        datesRef.whereEqualTo("userId", uniqueID).get()
+        datesRef.get()
                 .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
                     @Override
                     public void onComplete(@NonNull Task<QuerySnapshot> task) {
+
                         if (task.isSuccessful()) {
                             for (QueryDocumentSnapshot document : task.getResult()) {
-                                STUDY_ID_DATE.put(document.getString("studyId"), document.getString("date"));
+                                dbDatesList.add(document.getData());
                             }
-                            firestoreCallbackDates.onCallback();
+                            firestoreCallbackDates.onCallback(true);
                         }
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        firestoreCallbackDates.onCallback(false);
                     }
                 });
     }
 
-    //Parameters: id of the Study the user has set a date in
+    //Parameters
     //Return Values:
-    //this function adds all names and vps to hashmaps if the user has a booked date in it.
-    private static void getStudies(String studyID, FirestoreCallbackStudy firestoreCallbackStudies) {
-        String uniqueID = mainActivity.uniqueID; //before: homeActivity.uniqueID
+    //this function saves all Studie Documents from DB to static List
+    public static void getAllStudies(FirestoreCallbackStudy firestoreCallbackStudies) {
         db = FirebaseFirestore.getInstance();
         studiesRef = db.collection("studies");
-
-        studiesRef.whereEqualTo("id", studyID).get()
+        studiesRef.get()
                 .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
                     @Override
                     public void onComplete(@NonNull Task<QuerySnapshot> task) {
                         if (task.isSuccessful()) {
                             for (QueryDocumentSnapshot document : task.getResult()) {
-                                STUDY_ID_NAME.put(studyID, document.getString("name"));
-                                STUDY_ID_VPS.put(studyID, document.getString("vps"));
+                                dbStudiesList.add(document.getData());
+                                createListEntries();
                             }
                             firestoreCallbackStudies.onCallback();
                         }
@@ -151,67 +86,118 @@ public class PA_ExpandableListDataPump extends Activity {
 
     //Parameters
     //Return Values:
-    //this function searches for all studies the user created and adds them to a list.
-    private static void getOwnStudies(FirestoreCallbackOwnStudy firestoreCallbackOwnStudy) {
-        String uniqueID = mainActivity.uniqueID; //before: homeActivity.uniqueID
-        db = FirebaseFirestore.getInstance();
-        studiesRef = db.collection("studies");
+    //this function uses the date list and checks in which the users id is marked. By doing a check with the study list the name and vp count are found additionally to the date
+    //The List is than safed in a static variable to make it accessable from all other fragments
+    public static void createListEntries() {
 
-        studiesRef.whereEqualTo("creator", uniqueID).get()
-                .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
-                    @Override
-                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
-                        if (task.isSuccessful()) {
-                            for (QueryDocumentSnapshot document : task.getResult()) {
-                                OWN_STUDY_ID_NAME.put(document.getString("id"), document.getString("name"));
-                                OWN_STUDY_ID_VPS.put(document.getString("id"), document.getString("vps"));
+        HashMap<String, HashMap<String, String>> datesMap = new HashMap<>();
+        HashMap<String, HashMap<String, String>> studiesMap = new HashMap<>();
+
+        for (Map<String, Object> map : dbDatesList) {
+            String id = null;
+            HashMap<String, String> tempMap = new HashMap<>();
+            for (String key : map.keySet()) {
+                if (key.equals("id")) {
+                    id = map.get(key).toString();
+                }
+                Object value = map.get(key);
+                if (value == null) {
+                    tempMap.put(key, "null");
+                } else {
+                    tempMap.put(key, map.get(key).toString());
+                }
+            }
+            if (id != null) {
+                datesMap.put(id, tempMap);
+            }
+        }
+
+        for (Map<String, Object> map : dbStudiesList) {
+            String id = null;
+            HashMap<String, String> tempMap = new HashMap<>();
+            for (String key : map.keySet()) {
+                if (key.equals("id")) {
+                    id = map.get(key).toString();
+                }
+                Object value = map.get(key);
+                if (value == null) {
+                    tempMap.put(key, "null");
+                } else {
+                    tempMap.put(key, map.get(key).toString());
+                }
+            }
+            if (id != null) {
+                studiesMap.put(id, tempMap);
+            }
+        }
+
+        List<String> ownStudies = new ArrayList<>();
+        List<String> passedStudies = new ArrayList<>();
+
+        for (String id : datesMap.keySet()) {
+            HashMap<String, String> dateEntry = datesMap.get(id);
+            if (dateEntry != null) {
+                String dateString = dateEntry.get("date");
+                String selected = dateEntry.get("selected");
+                String userId = dateEntry.get("userId");
+
+                String StudyId = dateEntry.get("studyId");
+
+                if (Boolean.parseBoolean(selected) && userId != null) {
+                    if (userId.equals(uniqueID)) {
+                        HashMap<String, String> study = studiesMap.get(StudyId);
+                        if (study != null) {
+                            String studyNameString = study.get("name");
+                            String studyVPSString = study.get("vps");
+
+                            if(isDateInPast(dateString))
+                            {
+                                passedStudies.add(studyNameString + "," + studyVPSString + "," + dateString + "," + StudyId);
                             }
-                            firestoreCallbackOwnStudy.onCallback();
+                            else
+                                ownStudies.add(studyNameString + "," + studyVPSString + "," + dateString + "," + StudyId);
                         }
                     }
-                });
+                }
+            }
+        }
+
+        EXPANDABLE_LIST_DETAIL.put("Vergangene Studien", passedStudies);
+        EXPANDABLE_LIST_DETAIL.put("Geplante Studien", ownStudies);
     }
 
-    //Parameters: id of study in DB
-    //Return Values:
-    //this function uses the studyID to find all dates which belong to the study. Then all Dates where the userID is not null are added to a list.
-    private static void getAllBookedDatesForOwnStudies(String StudyID, FirestoreCallbackBookedDatesOfOwnStudy firestoreCallbackBookedDatesOfOwnStudy) {
-        String uniqueID = mainActivity.uniqueID; //before: homeActivity.uniqueID
-        db = FirebaseFirestore.getInstance();
-        datesRef = db.collection("dates");
 
-        ArrayList<String> dates = new ArrayList<>();
+    //Parameters: string date
+    //Return Values: boolean to tell if a date is in the future or past
+    //this function parses a given string to a date and checks if the date is already in the past, or in the future
+    private static boolean isDateInPast(String date) {
+        Date currentTime = Calendar.getInstance().getTime();
 
-        datesRef.whereEqualTo("studyId", StudyID).get()
-                .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
-                    @Override
-                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
-                        if (task.isSuccessful()) {
-                            for (QueryDocumentSnapshot document : task.getResult()) {
-                                if (document.getString("userId") != null && !document.getString("userId").equals("") && !document.getString("userId").equals("null")) {
-                                    dates.add(document.getString("date"));
-                                }
-                            }
-                            OWN_STUDY_ID_DATES.put(StudyID, dates);
-                            firestoreCallbackBookedDatesOfOwnStudy.onCallback();
-                        }
-                    }
-                });
+        SimpleDateFormat format = new SimpleDateFormat("dd-MM-yyyy HH:mm");
+
+        try {
+            Date meetingDate = format.parse(date);
+
+            if (currentTime.after(meetingDate))
+                return true;
+            else
+                return false;
+
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return false;
     }
+
+
+
+
 
     public interface FirestoreCallbackDates {
-        void onCallback();
+        void onCallback(boolean finished);
     }
 
     public interface FirestoreCallbackStudy {
-        void onCallback();
-    }
-
-    public interface FirestoreCallbackOwnStudy {
-        void onCallback();
-    }
-
-    public interface FirestoreCallbackBookedDatesOfOwnStudy {
         void onCallback();
     }
 }

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -189,7 +189,103 @@ public class PA_ExpandableListDataPump extends Activity {
         return false;
     }
 
+    //Parameters
+    //Return Values
+    //this function iterates over the date List and finds all dates that the user has selected. Then it adds all dates belonging to studies which the user created, if said date is selected by another user
+    public static List<String[]> getAllArrivingDates() {
+        HashMap<String, String> studyIdList = new HashMap<>();
 
+        List<String[]> arrivingDates = new ArrayList<>();
+
+        for (Map<String, Object> map : dbDatesList) {
+            boolean saveDate = false;
+            String studyId = null;
+            String userID = null;
+            String date = null;
+            for (String key : map.keySet()) {
+                if (key.equals("studyId")) {
+                    studyId = map.get(key).toString();
+                }
+                if (key.equals("date")) {
+                    date = map.get(key).toString();
+                }
+                if (key.equals("userId")) {
+                    userID = map.get(key).toString();
+                    if (userID == uniqueID) {
+                        saveDate = true;
+                    }
+                }
+            }
+            if (saveDate && studyId != null && date != null) {
+                studyIdList.put(studyId, date);
+            }
+        }
+
+        for (Map<String, Object> map : dbStudiesList) {
+            List<String> dateList = new ArrayList<>();
+            boolean getDate = false;
+            String studyID = null;
+            String creator = null;
+            for (String key : map.keySet()) {
+                if (key.equals("creator")) {
+                    creator = map.get(key).toString();
+                    if (creator.equals(uniqueID)) {
+                        getDate = true;
+                    }
+                }
+                if (key.equals("id")) {
+                    studyID = map.get(key).toString();
+                }
+            }
+            if (getDate && studyID != null) {
+                for (Map<String, Object> datemap : dbDatesList) {
+                    boolean saveDate = false;
+                    boolean dateBooked = false;
+                    String date = null;
+                    for (String key : datemap.keySet()) {
+                        if (key.equals("studyId")) {
+                            String dateStudyId = datemap.get(key).toString();
+                            if (dateStudyId.equals(studyID)) {
+                                saveDate = true;
+                            }
+                        }
+                        if (key.equals("date")) {
+                            date = datemap.get(key).toString();
+                        }
+                        if (key.equals("selected")) {
+                            dateBooked = Boolean.parseBoolean(datemap.get(key).toString());
+                        }
+                    }
+                    if (saveDate && dateBooked && date != null) {
+                        studyIdList.put(studyID, date);
+                    }
+                }
+            }
+        }
+
+        for (String key : studyIdList.keySet()) {
+            String studyName = null;
+            String date = studyIdList.get(key);
+
+            for (Map<String, Object> map : dbStudiesList) {
+                if (map.get("studyId").toString().equals(key)) {
+                    if (map.get("name").toString() != null) {
+                        studyName = map.get("name").toString();
+                    }
+                }
+            }
+
+            if (studyName != null) {
+                String[] listEntry = new String[3];
+                listEntry[0] = studyName;
+                listEntry[0] = date;
+                listEntry[0] = key;
+
+                arrivingDates.add(listEntry);
+            }
+        }
+        return arrivingDates;
+    }
 
 
 

--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -4,7 +4,6 @@ import static android.content.ContentValues.TAG;
 import static com.example.vpmanager.views.mainActivity.uniqueID;
 
 import android.app.Activity;
-import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -17,14 +16,11 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
-import java.lang.reflect.Array;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,8 +33,8 @@ public class PA_ExpandableListDataPump extends Activity {
     public static CollectionReference studiesRef;
     public static final HashMap<String, List<String>> EXPANDABLE_LIST_DETAIL = new HashMap<>();
 
-    public static final List<Map<String, Object>> dbDatesList = new ArrayList<>();
-    public static final List<Map<String, Object>> dbStudiesList = new ArrayList<>();
+    public static final List<Map<String, Object>> DB_DATES_LIST = new ArrayList<>();
+    public static final List<Map<String, Object>> DB_STUDIES_LIST = new ArrayList<>();
 
     //Parameters
     //Return Values:
@@ -53,7 +49,7 @@ public class PA_ExpandableListDataPump extends Activity {
 
                         if (task.isSuccessful()) {
                             for (QueryDocumentSnapshot document : task.getResult()) {
-                                dbDatesList.add(document.getData());
+                                DB_DATES_LIST.add(document.getData());
                             }
                             firestoreCallbackDates.onCallback(true);
                         }
@@ -79,7 +75,7 @@ public class PA_ExpandableListDataPump extends Activity {
                     public void onComplete(@NonNull Task<QuerySnapshot> task) {
                         if (task.isSuccessful()) {
                             for (QueryDocumentSnapshot document : task.getResult()) {
-                                dbStudiesList.add(document.getData());
+                                DB_STUDIES_LIST.add(document.getData());
                                 createListEntries();
                             }
                             firestoreCallbackStudies.onCallback();
@@ -97,7 +93,7 @@ public class PA_ExpandableListDataPump extends Activity {
         HashMap<String, HashMap<String, String>> datesMap = new HashMap<>();
         HashMap<String, HashMap<String, String>> studiesMap = new HashMap<>();
 
-        for (Map<String, Object> map : dbDatesList) {
+        for (Map<String, Object> map : DB_DATES_LIST) {
             String id = null;
             HashMap<String, String> tempMap = new HashMap<>();
             for (String key : map.keySet()) {
@@ -116,7 +112,7 @@ public class PA_ExpandableListDataPump extends Activity {
             }
         }
 
-        for (Map<String, Object> map : dbStudiesList) {
+        for (Map<String, Object> map : DB_STUDIES_LIST) {
             String id = null;
             HashMap<String, String> tempMap = new HashMap<>();
             for (String key : map.keySet()) {
@@ -200,7 +196,7 @@ public class PA_ExpandableListDataPump extends Activity {
 
         List<String[]> arrivingDates = new ArrayList<>();
 
-        for (Map<String, Object> map : dbDatesList) {
+        for (Map<String, Object> map : DB_DATES_LIST) {
             boolean saveDate = false;
             String studyId = null;
             String userID = null;
@@ -226,7 +222,7 @@ public class PA_ExpandableListDataPump extends Activity {
             }
         }
 
-        for (Map<String, Object> map : dbStudiesList) {
+        for (Map<String, Object> map : DB_STUDIES_LIST) {
             List<String> dateList = new ArrayList<>();
             boolean getDate = false;
             String studyID = null;
@@ -243,7 +239,7 @@ public class PA_ExpandableListDataPump extends Activity {
                 }
             }
             if (getDate && studyID != null) {
-                for (Map<String, Object> datemap : dbDatesList) {
+                for (Map<String, Object> datemap : DB_DATES_LIST) {
                     boolean saveDate = false;
                     boolean dateBooked = false;
                     String date = null;
@@ -272,7 +268,7 @@ public class PA_ExpandableListDataPump extends Activity {
             String studyName = null;
             String date = studyIdList.get(key);
 
-            for (Map<String, Object> map : dbStudiesList) {
+            for (Map<String, Object> map : DB_STUDIES_LIST) {
                 if (map.get("id").toString().equals(key)) {
                     if (map.get("name").toString() != null) {
                         studyName = map.get("name").toString();
@@ -304,7 +300,7 @@ public class PA_ExpandableListDataPump extends Activity {
 
     public static boolean navigateToStudyCreatorFragment(String currentUserId, String currentStudyId) {
 
-        if(dbStudiesList.size() <= 0)
+        if(DB_STUDIES_LIST.size() <= 0)
         {
             new Thread(() -> getAllStudies(() -> {       })).start();
 
@@ -314,7 +310,7 @@ public class PA_ExpandableListDataPump extends Activity {
                 e.printStackTrace();
             }
         }
-        for (Map<String, Object> map : dbStudiesList)
+        for (Map<String, Object> map : DB_STUDIES_LIST)
         {
             if (Objects.requireNonNull(map.get("creator")).toString().equals(currentUserId) &&
                     Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId))

--- a/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
@@ -43,6 +43,7 @@ public class editStudyFragment extends Fragment {
 
     Button saveButton;
     ArrayList<String> studyDateIds;
+
     //Parameter:
     //Return values:
     //Sets the current fragment for the activity
@@ -80,7 +81,7 @@ public class editStudyFragment extends Fragment {
     //Parameter:
     //Return values:
     //Connects the code with the view and sets Listener for Saving
-    private void setupView(View view){
+    private void setupView(View view) {
         title = view.findViewById(R.id.edit_study_title);
         vp = view.findViewById(R.id.edit_study_vp);
         category = view.findViewById(R.id.edit_study_category);
@@ -108,24 +109,21 @@ public class editStudyFragment extends Fragment {
     }
 
 
-
     //Parameter:
     //Return values: Map with all inputs from Edittexts
     //Loads data in a Map for the Database
-    private Map<String, Object> createDataMap()
-    {
+    private Map<String, Object> createDataMap() {
         Map<String, Object> dataMap = new HashMap<>();
-        dataMap.put("category", category.getText() );
-        dataMap.put("contact", contact.getText() );
-        dataMap.put("dates", studyDateIds );
-        dataMap.put("description", description.getText() );
-        dataMap.put("executionType", execution.getText() );
-        dataMap.put("name", title.getText() );
+        dataMap.put("category", category.getText());
+        dataMap.put("contact", contact.getText());
+        dataMap.put("dates", studyDateIds);
+        dataMap.put("description", description.getText());
+        dataMap.put("executionType", execution.getText());
+        dataMap.put("name", title.getText());
 
-        if(execution.getText().equals("Remote"))
-            dataMap.put("platform", location.getText() );
-        else if(execution.getText().equals("Präsenz"))
-        {
+        if (execution.getText().equals("Remote"))
+            dataMap.put("platform", location.getText());
+        else if (execution.getText().equals("Präsenz")) {
             String[] address = location.getText().toString().split("\n");
             dataMap.put("location", address[0]);
             dataMap.put("street", address[1]);
@@ -139,12 +137,10 @@ public class editStudyFragment extends Fragment {
     //Return values:
     //Loads data recieved from the database into the edittexts
     private void loadData() {
-
+        studyDateIds = new ArrayList<>();
         getAllStudies(() -> {
-            for(Map<String, Object> map : dbStudiesList)
-            {
-                if(Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId))
-                {
+            for (Map<String, Object> map : dbStudiesList) {
+                if (Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId)) {
                     title.setText(Objects.requireNonNull(map.get("name")).toString());
                     vp.setText(Objects.requireNonNull(map.get("vps")).toString());
                     category.setText(Objects.requireNonNull(map.get("category")).toString());
@@ -155,29 +151,29 @@ public class editStudyFragment extends Fragment {
                     contact.setText(Objects.requireNonNull(map.get("contact")).toString());
                     //dates.setText(Objects.requireNonNull(map.get("id")).toString());
 
-                    if(execution.getText().equals("Remote")) {
+                    if (execution.getText().equals("Remote")) {
                         location.setText(Objects.requireNonNull(map.get("platform")).toString());
-                    }
-                    else
-                    {
-                        String locationString = Objects.requireNonNull(map.get("location")).toString() + "\n "
-                                +Objects.requireNonNull(map.get("street")).toString()+ "\n "
-                                +Objects.requireNonNull(map.get("room")).toString();
+                    } else {
+                        if (map.get("location") != null) {
+                            String locationString = Objects.requireNonNull(map.get("location")).toString() + "\n "
+                                    + Objects.requireNonNull(map.get("street")).toString() + "\n "
+                                    + Objects.requireNonNull(map.get("room")).toString();
 
-                        location.setText(locationString);
+                            location.setText(locationString);
+                        }
                     }
 
                     StringBuilder dateList = new StringBuilder();
 
                     getAllDates(finished -> {
-                        if(finished)
-                        {
-                            for(Map<String, Object> dateMap: dbDatesList)
-                            {
-                                if(dateMap != null && Objects.requireNonNull(dateMap.get("studyId")).toString().equals(currentStudyId))
-                                {
+                        if (finished) {
+                            for (Map<String, Object> dateMap : dbDatesList) {
+                                if (dateMap != null && Objects.requireNonNull(dateMap.get("studyId")).toString().equals(currentStudyId)) {
                                     dateList.append(Objects.requireNonNull(dateMap.get("date")).toString()).append("\n");
-                                    studyDateIds.add(Objects.requireNonNull(dateMap.get("id")).toString());
+                                    System.out.println("Pog: " +dateMap.get("id"));
+                                    if (dateMap.get("id") != null) {
+                                        studyDateIds.add(Objects.requireNonNull(dateMap.get("id")).toString());
+                                    }
                                 }
                             }
                         }
@@ -186,11 +182,10 @@ public class editStudyFragment extends Fragment {
                 }
             }
         });
-        }
+    }
 
 
-    private void saveDataToDatabase(Map<String, Object> data)
-    {
+    private void saveDataToDatabase(Map<String, Object> data) {
         PA_ExpandableListDataPump.updateStudyInDataBase(data, currentStudyId);
     }
 }

--- a/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
@@ -1,0 +1,196 @@
+package com.example.vpmanager.views;
+
+import static com.example.vpmanager.PA_ExpandableListDataPump.dbDatesList;
+import static com.example.vpmanager.PA_ExpandableListDataPump.dbStudiesList;
+import static com.example.vpmanager.PA_ExpandableListDataPump.getAllDates;
+import static com.example.vpmanager.PA_ExpandableListDataPump.getAllStudies;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+
+import com.example.vpmanager.PA_ExpandableListDataPump;
+import com.example.vpmanager.R;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class editStudyFragment extends Fragment {
+
+    NavController navController;
+
+    String currentStudyId;
+    String currentUserId;
+
+    EditText title;
+    EditText vp;
+    EditText category;
+    EditText execution;
+    EditText location;
+    EditText description;
+    EditText dates;
+    EditText contact;
+
+    Button saveButton;
+    ArrayList<String> studyDateIds;
+    //Parameter:
+    //Return values:
+    //Sets the current fragment for the activity
+    public editStudyFragment() {
+        createStudyActivity.currentFragment = 7;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        getRequiredInfos();
+
+        return inflater.inflate(R.layout.fragment_edit_study, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        navController = Navigation.findNavController(view);
+        setupView(view);
+        loadData();
+    }
+
+    private void getRequiredInfos() {
+        //Get the studyId early
+        currentStudyId = getArguments().getString("studyId");
+        currentUserId = mainActivity.createUserId(getActivity());
+    }
+
+    //Parameter:
+    //Return values:
+    //Connects the code with the view and sets Listener for Saving
+    private void setupView(View view){
+        title = view.findViewById(R.id.edit_study_title);
+        vp = view.findViewById(R.id.edit_study_vp);
+        category = view.findViewById(R.id.edit_study_category);
+        execution = view.findViewById(R.id.edit_study_execution);
+        location = view.findViewById(R.id.edit_study_location);
+        description = view.findViewById(R.id.edit_study_description);
+        contact = view.findViewById(R.id.edit_study_contact);
+        dates = view.findViewById(R.id.edit_study_dates);
+
+        saveButton = view.findViewById(R.id.edit_saving_button);
+
+        saveButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                Map<String, Object> dataMap = createDataMap();
+
+                new Thread(() -> saveDataToDatabase(dataMap)).start();
+
+                Bundle args = new Bundle();
+                args.putString("studyId", currentStudyId);
+                navController.navigate(R.id.action_editStudyFragment_to_studyCreatorFragment, args);
+            }
+        });
+    }
+
+
+
+    //Parameter:
+    //Return values: Map with all inputs from Edittexts
+    //Loads data in a Map for the Database
+    private Map<String, Object> createDataMap()
+    {
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put("category", category.getText() );
+        dataMap.put("contact", contact.getText() );
+        dataMap.put("dates", studyDateIds );
+        dataMap.put("description", description.getText() );
+        dataMap.put("executionType", execution.getText() );
+        dataMap.put("name", title.getText() );
+
+        if(execution.getText().equals("Remote"))
+            dataMap.put("platform", location.getText() );
+        else if(execution.getText().equals("Präsenz"))
+        {
+            String[] address = location.getText().toString().split("\n");
+            dataMap.put("location", address[0]);
+            dataMap.put("street", address[1]);
+            dataMap.put("room", address[2]);
+        }
+
+        return dataMap;
+    }
+
+    //Parameter:
+    //Return values:
+    //Loads data recieved from the database into the edittexts
+    private void loadData() {
+
+        getAllStudies(() -> {
+            for(Map<String, Object> map : dbStudiesList)
+            {
+                if(Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId))
+                {
+                    title.setText(Objects.requireNonNull(map.get("name")).toString());
+                    vp.setText(Objects.requireNonNull(map.get("vps")).toString());
+                    category.setText(Objects.requireNonNull(map.get("category")).toString());
+                    execution.setText(Objects.requireNonNull(map.get("executionType")).toString());
+
+                    description.setText(Objects.requireNonNull(map.get("description")).toString());
+
+                    contact.setText(Objects.requireNonNull(map.get("contact")).toString());
+                    //dates.setText(Objects.requireNonNull(map.get("id")).toString());
+
+                    if(execution.getText().equals("Remote")) {
+                        location.setText(Objects.requireNonNull(map.get("platform")).toString());
+                    }
+                    else
+                    {
+                        String locationString = Objects.requireNonNull(map.get("location")).toString() + "\n "
+                                +Objects.requireNonNull(map.get("street")).toString()+ "\n "
+                                +Objects.requireNonNull(map.get("room")).toString();
+
+                        location.setText(locationString);
+                    }
+
+                    StringBuilder dateList = new StringBuilder();
+
+                    getAllDates(finished -> {
+                        if(finished)
+                        {
+                            for(Map<String, Object> dateMap: dbDatesList)
+                            {
+                                if(dateMap != null && Objects.requireNonNull(dateMap.get("studyId")).toString().equals(currentStudyId))
+                                {
+                                    dateList.append(Objects.requireNonNull(dateMap.get("date")).toString()).append("\n");
+                                    studyDateIds.add(Objects.requireNonNull(dateMap.get("id")).toString());
+                                }
+                            }
+                        }
+                    });
+                    dates.setText(dateList);
+                }
+            }
+        });
+        }
+
+
+    private void saveDataToDatabase(Map<String, Object> data)
+    {
+        PA_ExpandableListDataPump.updateStudyInDataBase(data, currentStudyId);
+    }
+}

--- a/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
@@ -1,7 +1,7 @@
 package com.example.vpmanager.views;
 
-import static com.example.vpmanager.PA_ExpandableListDataPump.dbDatesList;
-import static com.example.vpmanager.PA_ExpandableListDataPump.dbStudiesList;
+import static com.example.vpmanager.PA_ExpandableListDataPump.DB_DATES_LIST;
+import static com.example.vpmanager.PA_ExpandableListDataPump.DB_STUDIES_LIST;
 import static com.example.vpmanager.PA_ExpandableListDataPump.getAllDates;
 import static com.example.vpmanager.PA_ExpandableListDataPump.getAllStudies;
 
@@ -11,7 +11,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
@@ -142,7 +141,7 @@ public class editStudyFragment extends Fragment {
     private void loadData() {
         studyDateIds = new ArrayList<>();
         getAllStudies(() -> {
-            for (Map<String, Object> map : dbStudiesList) {
+            for (Map<String, Object> map : DB_STUDIES_LIST) {
                 if (Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId)) {
                     title.setText(Objects.requireNonNull(map.get("name")).toString());
                     name.setText(Objects.requireNonNull(map.get("name")).toString());
@@ -171,7 +170,7 @@ public class editStudyFragment extends Fragment {
 
                     getAllDates(finished -> {
                         if (finished) {
-                            for (Map<String, Object> dateMap : dbDatesList) {
+                            for (Map<String, Object> dateMap : DB_DATES_LIST) {
                                 if (dateMap != null && Objects.requireNonNull(dateMap.get("studyId")).toString().equals(currentStudyId)) {
                                     dateList.append(Objects.requireNonNull(dateMap.get("date")).toString()).append("\n");
                                     System.out.println("Pog: " +dateMap.get("id"));

--- a/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/editStudyFragment.java
@@ -22,6 +22,7 @@ import com.example.vpmanager.R;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,6 +34,7 @@ public class editStudyFragment extends Fragment {
     String currentUserId;
 
     EditText title;
+    EditText name;
     EditText vp;
     EditText category;
     EditText execution;
@@ -42,7 +44,7 @@ public class editStudyFragment extends Fragment {
     EditText contact;
 
     Button saveButton;
-    ArrayList<String> studyDateIds;
+    List<String> studyDateIds;
 
     //Parameter:
     //Return values:
@@ -83,6 +85,7 @@ public class editStudyFragment extends Fragment {
     //Connects the code with the view and sets Listener for Saving
     private void setupView(View view) {
         title = view.findViewById(R.id.edit_study_title);
+        name = view.findViewById(R.id.edit_study_name);
         vp = view.findViewById(R.id.edit_study_vp);
         category = view.findViewById(R.id.edit_study_category);
         execution = view.findViewById(R.id.edit_study_execution);
@@ -142,6 +145,7 @@ public class editStudyFragment extends Fragment {
             for (Map<String, Object> map : dbStudiesList) {
                 if (Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId)) {
                     title.setText(Objects.requireNonNull(map.get("name")).toString());
+                    name.setText(Objects.requireNonNull(map.get("name")).toString());
                     vp.setText(Objects.requireNonNull(map.get("vps")).toString());
                     category.setText(Objects.requireNonNull(map.get("category")).toString());
                     execution.setText(Objects.requireNonNull(map.get("executionType")).toString());

--- a/app/src/main/java/com/example/vpmanager/views/findStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/findStudyFragment.java
@@ -82,5 +82,6 @@ public class findStudyFragment extends Fragment implements StudyListAdapter.OnSt
         Log.d("findStudyFragment", "onStudyClick - studyId:" + studyId);
         args.putString("studyId", studyId);
         navController.navigate(R.id.action_findStudyFragment_to_studyFragment, args);
+                                  //action_findStudyFragment_to_studyFragment
     }
 }

--- a/app/src/main/java/com/example/vpmanager/views/findStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/findStudyFragment.java
@@ -1,5 +1,7 @@
 package com.example.vpmanager.views;
 
+import static com.example.vpmanager.views.mainActivity.uniqueID;
+
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -15,6 +17,7 @@ import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.example.vpmanager.PA_ExpandableListDataPump;
 import com.example.vpmanager.R;
 import com.example.vpmanager.adapter.StudyListAdapter;
 import com.example.vpmanager.viewmodels.FindStudyViewModel;
@@ -81,7 +84,11 @@ public class findStudyFragment extends Fragment implements StudyListAdapter.OnSt
         Bundle args = new Bundle();
         Log.d("findStudyFragment", "onStudyClick - studyId:" + studyId);
         args.putString("studyId", studyId);
-        navController.navigate(R.id.action_findStudyFragment_to_studyFragment, args);
-                                  //action_findStudyFragment_to_studyFragment
+        if(PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyId)) {
+            navController.navigate(R.id.action_findStudyFragment_to_studyCreatorFragment, args);
+        }
+        else {
+            navController.navigate(R.id.action_findStudyFragment_to_studyFragment, args);
+        }                         //action_findStudyFragment_to_studyFragment
     }
 }

--- a/app/src/main/java/com/example/vpmanager/views/homeFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/homeFragment.java
@@ -61,7 +61,7 @@ public class homeFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         navController = Navigation.findNavController(view);
         setNavCardClickListeners();
-        setUpDateList();
+        new Thread(this::setUpDateList).start();
     }
 
     //Parameter: the fragment view

--- a/app/src/main/java/com/example/vpmanager/views/homeFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/homeFragment.java
@@ -61,7 +61,7 @@ public class homeFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         navController = Navigation.findNavController(view);
         setNavCardClickListeners();
-        new Thread(this::setUpDateList).start();
+        setUpDateList();
     }
 
     //Parameter: the fragment view
@@ -122,15 +122,21 @@ public class homeFragment extends Fragment {
                         @Override
                         public void onCallback() {
                             arrivingDates[0] = PA_ExpandableListDataPump.getAllArrivingDates();
+                            finsishSetupList(arrivingDates[0]);
                         }
                     });
             }
         });
 
-        if (arrivingDates[0] != null) {
+    }
+
+    private  void finsishSetupList(List <String[]> dates){
+
+
+        if (dates != null) {
             SimpleDateFormat format = new SimpleDateFormat("dd-MM-yyyy HH:mm");
 
-            List<String[]> dates = arrivingDates[0];
+//            List<String[]> dates = arrivingDates[0];
             ArrayList<String> listEntries = new ArrayList<>();
 
             Map<Date, String> sortingMap = new TreeMap<>();

--- a/app/src/main/java/com/example/vpmanager/views/homeFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/homeFragment.java
@@ -122,15 +122,14 @@ public class homeFragment extends Fragment {
                         @Override
                         public void onCallback() {
                             arrivingDates[0] = PA_ExpandableListDataPump.getAllArrivingDates();
-                            finsishSetupList(arrivingDates[0]);
+                            finishSetupList(arrivingDates[0]);
                         }
                     });
             }
         });
-
     }
 
-    private  void finsishSetupList(List <String[]> dates){
+    private  void finishSetupList(List <String[]> dates){
 
 
         if (dates != null) {

--- a/app/src/main/java/com/example/vpmanager/views/homeFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/homeFragment.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
@@ -60,6 +61,7 @@ public class homeFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         navController = Navigation.findNavController(view);
         setNavCardClickListeners();
+        setUpDateList();
     }
 
     //Parameter: the fragment view

--- a/app/src/main/java/com/example/vpmanager/views/homeFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/homeFragment.java
@@ -1,5 +1,7 @@
 package com.example.vpmanager.views;
 
+import static com.example.vpmanager.views.mainActivity.uniqueID;
+
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -174,7 +176,13 @@ public class homeFragment extends Fragment {
                         //go to Study Detail View
                         Bundle args = new Bundle();
                         args.putString("studyId", studyId);
-                        navController.navigate(R.id.action_homeFragment_to_studyFragment, args);
+                        if(PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyId)) {
+                            navController.navigate(R.id.action_homeFragment_to_studyCreatorFragment, args);
+                        }
+                        else
+                        {
+                            navController.navigate(R.id.action_homeFragment_to_studyFragment, args);
+                        }
                     }
                 }
             });

--- a/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
@@ -56,10 +56,28 @@ public class personalAccountFragment extends Fragment {
         setupClickListener();
     }
 
+
+    private void loadData(View view)
+    {
+        PA_ExpandableListDataPump.getAllDates(new PA_ExpandableListDataPump.FirestoreCallbackDates() {
+            @Override
+            public void onCallback(boolean finished) {
+                if(finished)
+                    PA_ExpandableListDataPump.getAllStudies(new PA_ExpandableListDataPump.FirestoreCallbackStudy() {
+                        @Override
+                        public void onCallback() {
+                            PA_ExpandableListDataPump.createListEntries();
+                            setupView(view);
+                        }
+                    });
+            }
+        });
+    }
+
     private void setupView(View view) {
         listView = view.findViewById(R.id.pa_fragment_expandableList);
         chart = view.findViewById(R.id.pa_fragment_pie_chart);
-        expandableListDetail = PA_ExpandableListDataPump.getData();
+        expandableListDetail = PA_ExpandableListDataPump.EXPANDABLE_LIST_DETAIL;
         expandableListTitle = new ArrayList<String>(expandableListDetail.keySet());
         adapter = new PA_ExpandableListAdapter(getActivity(), expandableListTitle, expandableListDetail);
         listView.setAdapter(adapter);
@@ -74,6 +92,14 @@ public class personalAccountFragment extends Fragment {
                 String vps = vpList.get(i).split(",")[1];
                 double studyVPS = Double.parseDouble(vps);
                 plannedVP += studyVPS;
+            }
+        }
+        List<String> passedVpList = expandableListDetail.get("Vergangene Studien");
+        if (passedVpList != null) {
+            for (int i = 0; i < passedVpList.size(); i++) {
+                String vps = passedVpList.get(i).split(",")[1];
+                double studyVPS = Double.parseDouble(vps);
+                participatedVP += studyVPS;
             }
         }
         setPieChartData(completedVP, participatedVP, plannedVP);

--- a/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
@@ -53,7 +53,6 @@ public class personalAccountFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         navController = Navigation.findNavController(view);
-        setupClickListener();
     }
 
 
@@ -68,6 +67,7 @@ public class personalAccountFragment extends Fragment {
                         public void onCallback() {
                             PA_ExpandableListDataPump.createListEntries();
                             setupView(view);
+                            setupClickListener();
                         }
                     });
             }

--- a/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
@@ -45,7 +45,7 @@ public class personalAccountFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_personal_account, container, false);
-        setupView(view);
+        loadData(view);
         return view;
     }
 
@@ -57,12 +57,12 @@ public class personalAccountFragment extends Fragment {
     }
 
 
-    private void loadData(View view)
-    {
+    private void loadData(View view) {
+
         PA_ExpandableListDataPump.getAllDates(new PA_ExpandableListDataPump.FirestoreCallbackDates() {
             @Override
             public void onCallback(boolean finished) {
-                if(finished)
+                if (finished)
                     PA_ExpandableListDataPump.getAllStudies(new PA_ExpandableListDataPump.FirestoreCallbackStudy() {
                         @Override
                         public void onCallback() {

--- a/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/personalAccountFragment.java
@@ -1,5 +1,7 @@
 package com.example.vpmanager.views;
 
+import static com.example.vpmanager.views.mainActivity.uniqueID;
+
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -115,8 +117,12 @@ public class personalAccountFragment extends Fragment {
 
                 Bundle args = new Bundle();
                 args.putString("studyId", studyTitle);
-                navController.navigate(R.id.action_personalAccountFragment_to_studyFragment, args);
-
+                if(PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyTitle)) {
+                    navController.navigate(R.id.action_personalAccountFragment_to_studyCreatorFragment, args);
+                }
+                else {
+                    navController.navigate(R.id.action_personalAccountFragment_to_studyFragment, args);
+                }
                 return false;
             }
         });

--- a/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
@@ -28,7 +28,6 @@ import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
-import java.util.Objects;
 
 public class studyCreatorFragment extends Fragment {
 

--- a/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
@@ -77,13 +77,14 @@ public class studyCreatorFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_creator_study, container, false);
         getRequiredInfos();
-        navController = Navigation.findNavController(view);
+
         return view;
     }
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        navController = Navigation.findNavController(view);
         setupStudyDetails(new studyCreatorFragment.FirestoreCallbackStudy() {
             @Override
             public void onCallback(ArrayList<String> arrayList) {
@@ -143,6 +144,12 @@ public class studyCreatorFragment extends Fragment {
             String locationString = studyDetails.get(6) + "\t\t" + studyDetails.get(7) + "\t\t" + studyDetails.get(8);
             localData.setText(locationString);
         }
+
+        editButton.setOnClickListener(v -> {
+            Bundle args = new Bundle();
+            args.putString("studyId", currentStudyId);
+            navController.navigate(R.id.action_studyCreatorFragment_to_editStudyFragment, args);
+        });
     }
 
     private void loadDatesData(View view) {

--- a/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
@@ -28,6 +28,7 @@ import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class studyCreatorFragment extends Fragment {
 
@@ -42,9 +43,7 @@ public class studyCreatorFragment extends Fragment {
     ArrayList<String> dateIds;
     ArrayList<String> userIdsOfDates;
 
-    ArrayList<String> savedDateItem;
     ArrayAdapter availableDatesAdapter;
-    ArrayAdapter savedDateAdapter;
 
     FirebaseFirestore db;
     DocumentReference studyRef;
@@ -76,8 +75,6 @@ public class studyCreatorFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_creator_study, container, false);
-        getRequiredInfos();
-
         return view;
     }
 
@@ -85,6 +82,7 @@ public class studyCreatorFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         navController = Navigation.findNavController(view);
+        getRequiredInfos();
         setupStudyDetails(new studyCreatorFragment.FirestoreCallbackStudy() {
             @Override
             public void onCallback(ArrayList<String> arrayList) {
@@ -103,8 +101,7 @@ public class studyCreatorFragment extends Fragment {
         //Get the studyId early
         currentStudyId = getArguments().getString("studyId");
         currentUserId = mainActivity.createUserId(getActivity());
-        savedDateItem = new ArrayList<>();
-        savedDateItem.add(getString(R.string.dropDateView));
+
     }
 
     public interface FirestoreCallbackStudy {
@@ -216,7 +213,8 @@ public class studyCreatorFragment extends Fragment {
                                 idDateUser.add(0, document.getString("id"));
                                 idDateUser.add(1, document.getString("date"));
                                 idDateUser.add(2, document.getString("userId"));
-                                idDateUser.add(3, document.getString("selected"));
+                                boolean selected = Boolean.parseBoolean(document.getString("selected"));
+                                idDateUser.add(3, String.valueOf(selected));
 
                                 studyDatesInfo.add(idDateUser);
                             }

--- a/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyCreatorFragment.java
@@ -213,8 +213,7 @@ public class studyCreatorFragment extends Fragment {
                                 idDateUser.add(0, document.getString("id"));
                                 idDateUser.add(1, document.getString("date"));
                                 idDateUser.add(2, document.getString("userId"));
-                                boolean selected = Boolean.parseBoolean(document.getString("selected"));
-                                idDateUser.add(3, String.valueOf(selected));
+                                idDateUser.add(3, document.getBoolean("selected").toString());
 
                                 studyDatesInfo.add(idDateUser);
                             }
@@ -236,7 +235,7 @@ public class studyCreatorFragment extends Fragment {
                 if(allDates.get(k).equals(date))
                 {
                     String seleceted = studyDatesInfo.get(k).get(3);
-                    if(Boolean.parseBoolean(seleceted))
+                    if(Boolean.parseBoolean(seleceted) && dateList.getChildAt(i) != null)
                     {
                         dateList.getChildAt(i).setBackgroundColor(Color.GREEN);
                     }

--- a/app/src/main/java/com/example/vpmanager/views/studyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyFragment.java
@@ -108,35 +108,6 @@ public class studyFragment extends Fragment {
         //Get the studyId early
         currentStudyId = getArguments().getString("studyId");
         currentUserId = mainActivity.createUserId(getActivity());
-
-        if (PA_ExpandableListDataPump.dbDatesList.size() == 0) {
-            PA_ExpandableListDataPump.getAllDates(new PA_ExpandableListDataPump.FirestoreCallbackDates() {
-                @Override
-                public void onCallback(boolean finished) {
-                    completeRequiredInfos();
-                }
-            });
-        }
-        else
-            completeRequiredInfos();
-    }
-    private void completeRequiredInfos()
-    {
-        for (Map<String, Object> map : PA_ExpandableListDataPump.dbStudiesList)
-        {
-            if(map.get("creator").equals(currentUserId) && map.get("id").equals(currentStudyId)) {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                Bundle args = new Bundle();
-                args.putString("studyId", currentStudyId);
-                navController.navigate(R.id.action_studyFragment_to_studyCreatorFragment, args);
-
-            }
-        }
-
         savedDateItem = new ArrayList<>();
         savedDateItem.add(getString(R.string.dropDateView));
     }

--- a/app/src/main/java/com/example/vpmanager/views/studyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyFragment.java
@@ -81,7 +81,6 @@ public class studyFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_study, container, false);
-        getRequiredInfos();
         return view;
     }
 
@@ -89,6 +88,7 @@ public class studyFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         navController = Navigation.findNavController(view);
+        getRequiredInfos();
         setupStudyDetails(new studyFragment.FirestoreCallbackStudy() {
             @Override
             public void onCallback(ArrayList<String> arrayList) {

--- a/app/src/main/java/com/example/vpmanager/views/studyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyFragment.java
@@ -19,7 +19,6 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 
-import com.example.vpmanager.PA_ExpandableListDataPump;
 import com.example.vpmanager.R;
 import com.example.vpmanager.accessDatabase;
 import com.google.android.gms.tasks.OnCompleteListener;

--- a/app/src/main/java/com/example/vpmanager/views/studyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyFragment.java
@@ -81,7 +81,6 @@ public class studyFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_study, container, false);
-        navController = Navigation.findNavController(view);
         getRequiredInfos();
         return view;
     }
@@ -89,6 +88,7 @@ public class studyFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        navController = Navigation.findNavController(view);
         setupStudyDetails(new studyFragment.FirestoreCallbackStudy() {
             @Override
             public void onCallback(ArrayList<String> arrayList) {

--- a/app/src/main/java/com/example/vpmanager/views/studyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/studyFragment.java
@@ -81,6 +81,7 @@ public class studyFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_study, container, false);
+
         return view;
     }
 
@@ -108,23 +109,31 @@ public class studyFragment extends Fragment {
         currentStudyId = getArguments().getString("studyId");
         currentUserId = mainActivity.createUserId(getActivity());
 
-        if(PA_ExpandableListDataPump.dbDatesList.size() == 0)
-        {
+        if (PA_ExpandableListDataPump.dbDatesList.size() == 0) {
             PA_ExpandableListDataPump.getAllDates(new PA_ExpandableListDataPump.FirestoreCallbackDates() {
                 @Override
                 public void onCallback(boolean finished) {
-
+                    completeRequiredInfos();
                 }
             });
         }
-
+        else
+            completeRequiredInfos();
+    }
+    private void completeRequiredInfos()
+    {
         for (Map<String, Object> map : PA_ExpandableListDataPump.dbStudiesList)
         {
-            if(map.get("creator").equals(currentUserId) && map.get("id").equals(currentStudyId))
-            {
+            if(map.get("creator").equals(currentUserId) && map.get("id").equals(currentStudyId)) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
                 Bundle args = new Bundle();
                 args.putString("studyId", currentStudyId);
                 navController.navigate(R.id.action_studyFragment_to_studyCreatorFragment, args);
+
             }
         }
 

--- a/app/src/main/res/layout/fragment_creator_study.xml
+++ b/app/src/main/res/layout/fragment_creator_study.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:context=".views.studyFragment">
+
+    <TextView
+        android:id="@+id/studyFragmentHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="25dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginEnd="25dp"
+        android:layout_marginBottom="10dp"
+        android:textSize="23sp"
+        android:textStyle="bold" />
+    <!--android:text="@string/studyViewHeader"-->
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:layout_marginLeft="20dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginBottom="15dp"
+        android:background="@color/color_two" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+        <ImageView
+            android:id="@+id/infoSymbolStudyFragment"
+            android:layout_width="91dp"
+            android:layout_height="29dp"
+            android:layout_marginTop="10dp"
+            app:srcCompat="@drawable/ic_baseline_info_24" />
+
+        <ImageView
+            android:id="@+id/editOwnStudyButton"
+            android:layout_width="91dp"
+            android:layout_height="29dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginLeft="200dp"
+            app:srcCompat="@drawable/ic_baseline_create_24" />
+
+    </LinearLayout>
+    <TextView
+        android:id="@+id/descriptionStudyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="35dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="35dp"
+        android:fontFamily="sans-serif-light"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:weightSum="100" />
+
+    <TextView
+        android:id="@+id/vpValueStudyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="35dp"
+        android:layout_marginEnd="35dp"
+        android:fontFamily="sans-serif-light"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:weightSum="100" />
+
+    <TextView
+        android:id="@+id/categoryStudyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="35dp"
+        android:layout_marginEnd="35dp"
+        android:fontFamily="sans-serif-light"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:weightSum="100" />
+
+    <TextView
+        android:id="@+id/contactInformationStudyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="35dp"
+        android:layout_marginEnd="35dp"
+        android:fontFamily="sans-serif-light"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:weightSum="100" />
+
+
+    <ImageView
+        android:id="@+id/locationSymbolStudyFragment"
+        android:layout_width="91dp"
+        android:layout_height="31dp"
+        android:layout_marginTop="30dp"
+        app:srcCompat="@drawable/ic_round_location_on_24" />
+
+    <TextView
+        android:id="@+id/studyTypeStudyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="35dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="35dp"
+        android:fontFamily="sans-serif-light"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:weightSum="100" />
+
+    <!--  adapt design to studyType Textview-->
+    <TextView
+        android:id="@+id/remoteStudyStudyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="35dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="35dp"
+        android:fontFamily="sans-serif-light"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:weightSum="100" />
+
+    <!-- position mit remoteStudy TextView Ã¼berlagern!-->
+    <TextView
+        android:id="@+id/localStudyStudyFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginStart="35dp"
+        android:layout_marginTop="-25dp"
+        android:layout_marginEnd="35dp"
+        android:fontFamily="sans-serif-light"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:weightSum="100" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:layout_marginLeft="20dp"
+        android:layout_marginTop="35dp"
+        android:layout_marginRight="20dp"
+        android:background="@color/color_two" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="20dp"
+        android:text="@string/dateListHeader"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <ListView
+        android:id="@+id/listViewDatesStudyFragment"
+        android:layout_width="348dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="3dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_edit_study.xml
+++ b/app/src/main/res/layout/fragment_edit_study.xml
@@ -198,7 +198,7 @@
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
 
-                <ListView
+                <EditText
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/edit_study_dates"
@@ -207,7 +207,7 @@
                     android:layout_marginTop="10dp"
                     android:layout_marginLeft="15dp"
                     android:layout_marginRight="15dp">
-                </ListView>
+                </EditText>
 
             </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/fragment_edit_study.xml
+++ b/app/src/main/res/layout/fragment_edit_study.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".views.createStudyFragment_finalStep"
+    android:background="?android:windowBackground">
+
+
+    <ScrollView
+        android:id="@+id/fragment_edit_study_scrollView"
+        android:background="#000000"
+        android:layout_width="match_parent"
+        android:fillViewport="true"
+        android:layout_height="match_parent" >
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:weightSum="10">
+
+            <EditText
+                android:id="@+id/edit_study_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Edit Study"
+                android:textAlignment="center"
+                android:textSize="35sp" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="3dp"
+                android:layout_marginLeft="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginRight="20dp"
+                android:background="@color/black" />
+
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1.5"
+
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_name"
+                    android:textSize="20sp"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="10dp">
+                </EditText>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1.5"
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_vp"
+                    android:textSize="20sp"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="10dp">
+                </EditText>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1.5"
+
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_category"
+                    android:textSize="20sp"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="10dp">
+                </EditText>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="6"
+
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_execution"
+                    android:textSize="20sp"
+                    android:gravity="top"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginTop="5dp">
+                </EditText>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1.5"
+
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_location"
+                    android:textSize="20sp"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="10dp">
+                </EditText>
+            </com.google.android.material.card.MaterialCardView>
+
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="3dp"
+                android:layout_marginLeft="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginRight="20dp"
+                android:background="@color/black" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="6"
+
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_description"
+                    android:textSize="20sp"
+                    android:gravity="top"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginTop="5dp">
+                </EditText>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="3"
+
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <EditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_contact"
+                    android:textSize="20sp"
+                    android:layout_marginStart="10dp">
+                </EditText>
+            </com.google.android.material.card.MaterialCardView>
+
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="3dp"
+                android:layout_marginLeft="20dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginRight="20dp"
+                android:background="@color/black" />
+
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="6.5"
+
+                android:layout_marginRight="30dp"
+                android:layout_marginLeft="30dp"
+                android:layout_marginTop="20dp">
+
+                <ListView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/edit_study_dates"
+                    android:textSize="20sp"
+                    android:layout_gravity="top"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginLeft="15dp"
+                    android:layout_marginRight="15dp">
+                </ListView>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="5dp"
+                android:id="@+id/edit_saving_button"/>
+        </LinearLayout>
+
+
+    </ScrollView>
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_edit_study.xml
+++ b/app/src/main/res/layout/fragment_edit_study.xml
@@ -26,6 +26,7 @@
                 android:layout_height="wrap_content"
                 android:text="Edit Study"
                 android:textAlignment="center"
+                android:textColor="@color/white"
                 android:textSize="35sp" />
 
             <View
@@ -45,6 +46,11 @@
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Name der Studie"/>
 
                 <EditText
                     android:layout_width="match_parent"
@@ -59,10 +65,15 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="1.5"
+                android:layout_weight="1"
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Versuchspersonenestunden"/>
 
                 <EditText
                     android:layout_width="match_parent"
@@ -77,12 +88,16 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="1.5"
+                android:layout_weight="1"
 
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
-
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Kategorie"/>
                 <EditText
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -96,11 +111,17 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="6"
+                android:layout_weight="1"
 
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Durchführungsart"/>
 
                 <EditText
                     android:layout_width="match_parent"
@@ -116,11 +137,17 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="1.5"
+                android:layout_weight="1"
 
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Ort/Plattform"/>
 
                 <EditText
                     android:layout_width="match_parent"
@@ -144,11 +171,17 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="6"
+                android:layout_weight="1"
 
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Studienbeschreibung"/>
 
                 <EditText
                     android:layout_width="match_parent"
@@ -164,11 +197,17 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="3"
+                android:layout_weight="1"
 
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Kontaktmöglichkeit"/>
 
                 <EditText
                     android:layout_width="match_parent"
@@ -192,12 +231,17 @@
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="6.5"
+                android:layout_weight="2"
 
                 android:layout_marginRight="30dp"
                 android:layout_marginLeft="30dp"
                 android:layout_marginTop="20dp">
 
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text="Termine"/>
                 <EditText
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -215,6 +259,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_margin="5dp"
+                android:text="Save Study"
                 android:id="@+id/edit_saving_button"/>
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -41,37 +41,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="25dp"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="30dp"
         android:layout_marginEnd="25dp"
         android:text="Anstehende Termine"
         android:textSize="20sp"
         android:textStyle="bold" />
 
-    <TextView
+    <ListView
+        android:id="@+id/listViewOwnArrivingStudyFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="25dp"
+        android:layout_height="match_parent"
         android:layout_marginTop="20dp"
-        android:layout_marginEnd="25dp"
-        android:text="Termin 1"
-        android:textSize="15sp" />
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="25dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="25dp"
-        android:text="Termin 2"
-        android:textSize="15sp" />
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="25dp"
-        android:layout_marginTop="20dp"
-        android:layout_marginEnd="25dp"
-        android:text="Termin 3"
-        android:textSize="15sp" />
+        android:layout_weight="1"
+        android:dividerHeight="2dp" />
 
 </LinearLayout>

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -98,6 +98,18 @@
         <argument
             android:name="study_id"
             app:argType="string" />
+        <action
+            android:id="@+id/action_studyFragment_to_studyCreatorFragment"
+            app:destination="@id/studyCreatorFragment"
+            app:popUpTo="@id/studyCreatorFragment"
+            app:popUpToInclusive="true" />
     </fragment>
-
+    <fragment
+        android:id="@+id/studyCreatorFragment"
+        android:name="com.example.vpmanager.views.studyCreatorFragment"
+        android:label="studyCreatorFragment">
+        <argument
+            android:name="study_id"
+            app:argType="string" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -111,5 +111,23 @@
         <argument
             android:name="study_id"
             app:argType="string" />
+        <action
+            android:id="@+id/action_studyCreatorFragment_to_editStudyFragment"
+            app:destination="@id/editStudyFragment"
+            app:popUpTo="@id/editStudyFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/editStudyFragment"
+        android:name="com.example.vpmanager.views.editStudyFragment"
+        android:label="editStudyFragment" >
+    <argument
+        android:name="study_id"
+        app:argType="string" />
+        <action
+            android:id="@+id/action_editStudyFragment_to_studyCreatorFragment"
+            app:destination="@id/studyCreatorFragment"
+            app:popUpTo="@id/studyCreatorFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -52,6 +52,11 @@
             app:destination="@id/personalAccountFragment"
             app:popUpTo="@id/personalAccountFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_homeFragment_to_studyFragment"
+            app:destination="@id/studyFragment"
+            app:popUpTo="@id/studyFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/findStudyFragment"

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -57,6 +57,11 @@
             app:destination="@id/studyFragment"
             app:popUpTo="@id/studyFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_homeFragment_to_studyCreatorFragment"
+            app:destination="@id/studyCreatorFragment"
+            app:popUpTo="@id/studyCreatorFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/findStudyFragment"
@@ -67,6 +72,11 @@
             android:id="@+id/action_findStudyFragment_to_studyFragment"
             app:destination="@id/studyFragment"
             app:popUpTo="@id/studyFragment"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_findStudyFragment_to_studyCreatorFragment"
+            app:destination="@id/studyCreatorFragment"
+            app:popUpTo="@id/studyCreatorFragment"
             app:popUpToInclusive="true" />
     </fragment>
     <activity
@@ -84,6 +94,11 @@
             app:destination="@id/studyFragment"
             app:popUpTo="@id/studyFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_personalAccountFragment_to_studyCreatorFragment"
+            app:destination="@id/studyCreatorFragment"
+            app:popUpTo="@id/studyCreatorFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/ownStudyFragment"
@@ -98,11 +113,6 @@
         <argument
             android:name="study_id"
             app:argType="string" />
-        <action
-            android:id="@+id/action_studyFragment_to_studyCreatorFragment"
-            app:destination="@id/studyCreatorFragment"
-            app:popUpTo="@id/studyCreatorFragment"
-            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/studyCreatorFragment"


### PR DESCRIPTION
Reworked the personal Account and added a overview for all arriving studies. Created a detail view for self created studies and a fragment to edit own studies.

Because:
 - users had to reload personal account activity to see the data (issue #50 )
 - In personal account where all studies, including those that were scheduled in the past (issue #67 )
 - Detailview for own allows user to see all the dates (issue #69 )
 
 For #50 the database calls where resturctured to insure that the fragment is loaded only after the data has arrived from the databse.
 In #67 a listview containing future studies was added to the home fragment. Both own studies and studies the user participates in are listed there. A click listener was added to make the studies easier accessable.
In order to check if the user is accessing the details of their own study, or the study of another user, a switch was created to check the creator id before loading the detailview. if the user is the creator, another fragment is called, which allows the user to see all dates, not only the remaining ones. A button is also added to allow the user to change the contents of the description etc. (#69)
 