### PR TITLE
Navigation drawer header overlap and double load in findStudyFragment…

### DIFF
--- a/app/src/main/java/com/example/vpmanager/views/findStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/findStudyFragment.java
@@ -20,7 +20,17 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.example.vpmanager.PA_ExpandableListDataPump;
 import com.example.vpmanager.R;
 import com.example.vpmanager.adapter.StudyListAdapter;
+import com.example.vpmanager.models.StudyMetaInfoModel;
 import com.example.vpmanager.viewmodels.FindStudyViewModel;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
 
 public class findStudyFragment extends Fragment implements StudyListAdapter.OnStudyItemClickListener {
 
@@ -28,6 +38,14 @@ public class findStudyFragment extends Fragment implements StudyListAdapter.OnSt
     private RecyclerView studyList;
     private StudyListAdapter studyListAdapter;
     private FindStudyViewModel findStudyViewModel;
+
+
+    private FirebaseFirestore db;
+    private CollectionReference studiesRef;
+
+    private ArrayList<ArrayList<String>> studyIdNameVpCat;
+
+    private ArrayList<StudyMetaInfoModel> studyMetaInfosArrayList = new ArrayList<>();
 
     public findStudyFragment() {
     }
@@ -43,9 +61,12 @@ public class findStudyFragment extends Fragment implements StudyListAdapter.OnSt
         View view = inflater.inflate(R.layout.fragment_find_study, container, false);
         initFindStudyFragmentComponents(view);
         //data is first retrieved from the viewModel...
-        findStudyViewModel.init();
-        //...and passed to the adapter later.
-        connectStudyListAdapter();
+
+        getData();
+        //...and passed to the
+        //
+        // later.
+
         return view;
     }
 
@@ -53,6 +74,19 @@ public class findStudyFragment extends Fragment implements StudyListAdapter.OnSt
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         navController = Navigation.findNavController(view);
         super.onViewCreated(view, savedInstanceState);
+
+
+    }
+
+
+    private void getData() {
+        getStudyInfosFromDB(new FirestoreCallback() {
+            @Override
+            public void onCallback() {
+                setStudyMetaInfo();
+                connectStudyListAdapter();
+            }
+        });
     }
 
     //Parameter: the fragment view
@@ -68,10 +102,10 @@ public class findStudyFragment extends Fragment implements StudyListAdapter.OnSt
     //Return Values:
     //sets the adapter to connect the recyclerview with the data
     private void connectStudyListAdapter() {
-        Log.d("findStudyFragment", "Size of Array:" + findStudyViewModel.getStudyMetaInfo().size());
+        // Log.d("findStudyFragment", "Size of Array:" + findStudyViewModel.getStudyMetaInfo().size());
         LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getActivity());
         studyListAdapter = new StudyListAdapter(requireActivity(),
-                findStudyViewModel.getStudyMetaInfo(), this);
+                studyMetaInfosArrayList, this);
         studyList.setAdapter(studyListAdapter);
         studyList.setLayoutManager(linearLayoutManager);
     }
@@ -84,11 +118,64 @@ public class findStudyFragment extends Fragment implements StudyListAdapter.OnSt
         Bundle args = new Bundle();
         Log.d("findStudyFragment", "onStudyClick - studyId:" + studyId);
         args.putString("studyId", studyId);
-        if(PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyId)) {
+        if (PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyId)) {
             navController.navigate(R.id.action_findStudyFragment_to_studyCreatorFragment, args);
-        }
-        else {
+        } else {
             navController.navigate(R.id.action_findStudyFragment_to_studyFragment, args);
         }                         //action_findStudyFragment_to_studyFragment
     }
+
+
+    private interface FirestoreCallback {
+        void onCallback();
+    }
+
+    private void getStudyInfosFromDB(FirestoreCallback firestoreCallback) {
+        Log.d("StudyListRepository", "getStudyInfosFromDB start");
+        db = FirebaseFirestore.getInstance();
+        studiesRef = db.collection("studies");
+        studyIdNameVpCat = new ArrayList<>();
+
+        //all studies are retrieved, sorted alphabetically by their names
+        studiesRef.orderBy("name", Query.Direction.DESCENDING)
+                .get()
+                .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                    @Override
+                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                        if (task.isSuccessful()) {
+                            for (QueryDocumentSnapshot document : task.getResult()) {
+                                //local ArrayList is stored in the big ArrayList for each existing study
+                                ArrayList<String> idNameVphCat = new ArrayList<>();
+                                idNameVphCat.add(0, document.getString("id"));
+                                idNameVphCat.add(1, document.getString("name"));
+                                idNameVphCat.add(2, document.getString("vps"));
+                                idNameVphCat.add(3, document.getString("category"));
+                                studyIdNameVpCat.add(idNameVphCat);
+                            }
+                            firestoreCallback.onCallback();
+                        } else {
+                            Log.d("getStudyInfosFromDB", "Error:" + task.getException());
+                        }
+                    }
+                });
+        Log.d("StudyListRepository", "getStudyInfosFromDB end");
+    }
+
+    private void setStudyMetaInfo() {
+        Log.d("StudyListRepository", "setStudyMetaInfo start");
+        //THE LIST NEEDS TO BE CLEARED BEFORE, BECAUSE THE REPO-INSTANCE IS THE SAME AND IT ISN'T CREATED NEW!
+        studyMetaInfosArrayList.clear();
+        //new data is stored in the list
+        for (int i = 0; i < studyIdNameVpCat.size(); i++) {
+            studyMetaInfosArrayList.add(
+                    new StudyMetaInfoModel(
+                            studyIdNameVpCat.get(i).get(0), //add Id
+                            studyIdNameVpCat.get(i).get(1), //add Name
+                            studyIdNameVpCat.get(i).get(2) + " " + "VP-Stunden", //add vps
+                            studyIdNameVpCat.get(i).get(3)) //add category
+            );
+        }
+        Log.d("StudyListRepository", "setStudyMetaInfo end");
+    }
+
 }

--- a/app/src/main/res/layout/header_navigation_drawer.xml
+++ b/app/src/main/res/layout/header_navigation_drawer.xml
@@ -9,7 +9,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="12dp"
         android:layout_marginEnd="24dp"
         android:text="VP Manager"
         android:textAppearance="?attr/textAppearanceHeadline6" />


### PR DESCRIPTION
Navigation drawer header overlap and double load in findStudyFragment.java fixed

Because:
-header was nearly invisible due to overlap
- findStudyFragment.java had to be opened twice to display

Reorganized structure for findStudyFragment.java and changed header margin for the navigation drawer header.