### PR TITLE
personalAccount as starting Point

### DIFF
--- a/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapter.java
+++ b/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapter.java
@@ -1,0 +1,178 @@
+package com.example.vpmanager.adapter;
+
+import static com.example.vpmanager.views.mainActivity.uniqueID;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+
+import androidx.navigation.NavController;
+
+import com.example.vpmanager.PA_ExpandableListDataPump;
+import com.example.vpmanager.R;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class CustomListViewAdapter extends BaseAdapter {
+
+    private LayoutInflater inflater;
+    private ArrayList<StudyObject> objects;
+    private Activity activity;
+    NavController navController;
+
+
+    private class ViewHolder {
+        TextView titleTextView;
+        TextView dateTextView;
+        TextView vpsTextView;
+        View colorView;
+
+    }
+
+    public CustomListViewAdapter(Context context, Activity activity, NavController nav) {
+        super();
+        inflater = LayoutInflater.from(context);
+        navController = nav;
+        this.objects = transformLists();
+        this.activity = activity;
+    }
+
+    private ArrayList<StudyObject> transformLists() {
+        ArrayList<StudyObject> list = new ArrayList<>();
+        HashMap<String, List<String>> dataList = PA_ExpandableListDataPump.EXPANDABLE_LIST_DETAIL;
+
+        for (String key : dataList.keySet()) {
+            List<String> tempList = dataList.get(key);
+
+            for (int i = 0; i < (tempList != null ? tempList.size() : 0); i++) {
+                String[] values = tempList.get(i).split(",");
+                StudyObject object = null;
+
+                switch (key) {
+                    case "Vergangene Studien":
+                        object = new StudyObject(values[0], values[1], values[3], values[2], R.color.pieChartParticipation);
+                        break;
+                    case "Geplante Studien":
+                        object = new StudyObject(values[0], values[1], values[3], values[2], R.color.pieChartPlanned);
+                        break;
+                    case "Abgeschlossene Studien":
+                        object = new StudyObject(values[0], values[1], values[3], values[2], R.color.pieChartSafe);
+                        break;
+                    default:
+                        object = new StudyObject(values[0], values[1], values[3], values[2], R.color.heatherred_dark);
+                        break;
+                }
+                if (object != null) {
+                    list.add(object);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    @Override
+    public int getCount() {
+        return objects.size();
+    }
+
+    @Override
+    public StudyObject getItem(int position) {
+        return objects.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        ViewHolder holder = null;
+        TextView titleView = null, vpsView = null, dateView = null;
+        View colorView = null;
+        if (convertView == null) {
+            holder = new ViewHolder();
+            convertView = inflater.inflate(R.layout.pa_listview_item, null); //NOT SURE
+
+            titleView = convertView.findViewById(R.id.listviewItemTitle);
+            titleView.setText(objects.get(position).title);
+
+            vpsView = convertView.findViewById(R.id.pa_VP_view);
+            vpsView.setText(objects.get(position).vps);
+
+            dateView = convertView.findViewById(R.id.pa_date_view);
+            dateView.setText(objects.get(position).date);
+
+            colorView = convertView.findViewById(R.id.pa_listView_colorTag);
+            colorView.setBackgroundResource(objects.get(position).color);
+
+
+            convertView.setTag(objects);
+
+            holder.titleTextView = titleView;
+            holder.dateTextView = dateView;
+            holder.vpsTextView = vpsView;
+            holder.colorView = colorView;
+            convertView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Bundle args = new Bundle();
+                    StudyObject study = objects.get(position);
+                    args.putString("studyId", study.getStudyId());
+                    if (PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, study.getStudyId())) {
+                        navController.navigate(R.id.action_homeFragment_to_studyCreatorFragment, args);
+                    } else {
+                        navController.navigate(R.id.action_homeFragment_to_studyFragment, args);
+                    }
+                }
+            });
+        }
+        return convertView;
+    }
+}
+class StudyObject
+{
+    String title;
+    String vps;
+    String studyId;
+    String date;
+    int color;
+
+    public StudyObject(String _title, String _vps, String _studyId, String _date, int _color)
+    {
+        title = _title;
+        vps = _vps;
+        studyId = _studyId;
+        date = _date;
+        color = _color;
+    }
+
+    public String getTitle()
+    {
+        return title;
+    }
+    public String getDate()
+    {
+        return date;
+    }
+    public String getVps()
+    {
+        return vps;
+    }
+    public String getStudyId()
+    {
+        return studyId;
+    }
+    public int getColor()
+    {
+        return color;
+    }
+}

--- a/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapterAppointments.java
+++ b/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapterAppointments.java
@@ -1,0 +1,110 @@
+package com.example.vpmanager.adapter;
+
+import static com.example.vpmanager.views.mainActivity.uniqueID;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+
+import androidx.navigation.NavController;
+
+import com.example.vpmanager.PA_ExpandableListDataPump;
+import com.example.vpmanager.R;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class CustomListViewAdapterAppointments extends BaseAdapter {
+
+    private LayoutInflater inflater;
+    private ArrayList<StudyObject> objects;
+    private Activity activity;
+    NavController navController;
+
+
+    private class ViewHolder {
+        TextView titleTextView;
+        TextView dateTextView;
+
+    }
+
+    public CustomListViewAdapterAppointments(Context context, Activity activity, NavController nav, ArrayList<String> list, HashMap<String, String> getStudyIdByName) {
+        super();
+        inflater = LayoutInflater.from(context);
+        navController = nav;
+        this.objects = transformUpcomingAppointments(list, getStudyIdByName);
+        this.activity = activity;
+    }
+
+    private ArrayList<StudyObject> transformUpcomingAppointments(ArrayList<String> list, HashMap<String, String> getStudyIdByName) {
+        ArrayList<StudyObject> returnList = new ArrayList<>();
+
+        for(int i = 0; i < list.size(); i++)
+        {
+            String[] values = list.get(i).split("\t\t");//0 name 1 date
+            String id = getStudyIdByName.get(values[0]);
+            assert id != null;
+            if(!id.equals("")) {
+                StudyObject object = new StudyObject(values[0],null, id, values[1], 0);
+                returnList.add(object);
+            }
+        }
+        return returnList;
+    }
+
+    @Override
+    public int getCount() {
+        return objects.size();
+    }
+
+    @Override
+    public StudyObject getItem(int position) {
+        return objects.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        ViewHolder holder = null;
+        TextView titleView = null, vpsView = null, dateView = null;
+        View colorView = null;
+        if (convertView == null) {
+            holder = new ViewHolder();
+            convertView = inflater.inflate(R.layout.pa_upcoming_listview_item, null); //NOT SURE
+
+            titleView = convertView.findViewById(R.id.upcoming_listviewItemTitle);
+            titleView.setText(objects.get(position).title);
+
+            dateView = convertView.findViewById(R.id.pa_upcoming_date_view);
+            dateView.setText(objects.get(position).date);
+
+            convertView.setTag(objects);
+
+            holder.titleTextView = titleView;
+            holder.dateTextView = dateView;
+            convertView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Bundle args = new Bundle();
+                    StudyObject study = objects.get(position);
+                    args.putString("studyId", study.getStudyId());
+                    if (PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, study.getStudyId())) {
+                        navController.navigate(R.id.action_homeFragment_to_studyCreatorFragment, args);
+                    } else {
+                        navController.navigate(R.id.action_homeFragment_to_studyFragment, args);
+                    }
+                }
+            });
+        }
+        return convertView;
+    }
+}

--- a/app/src/main/java/com/example/vpmanager/views/UpcomingAppointments.java
+++ b/app/src/main/java/com/example/vpmanager/views/UpcomingAppointments.java
@@ -1,13 +1,9 @@
 package com.example.vpmanager.views;
 
-import static com.example.vpmanager.views.mainActivity.uniqueID;
-
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
 import androidx.annotation.NonNull;
@@ -18,6 +14,7 @@ import androidx.navigation.Navigation;
 
 import com.example.vpmanager.PA_ExpandableListDataPump;
 import com.example.vpmanager.R;
+import com.example.vpmanager.adapter.CustomListViewAdapterAppointments;
 import com.google.firebase.auth.FirebaseAuth;
 
 import java.text.ParseException;
@@ -69,7 +66,9 @@ public class UpcomingAppointments extends Fragment {
 
     }
 
-
+    //Parameter:
+    //Return Values:
+    //gets necessary data from database converts it into a list
     private void setUpDateList() {
         final List<String[]>[] arrivingDates = new List[]{null};
 
@@ -88,8 +87,10 @@ public class UpcomingAppointments extends Fragment {
         });
     }
 
+    //Parameter: data list from database call
+    //Return Values:
+    //converts and sorts the data. calls listview adapter to set up list entries
     private  void finishSetupList(List <String[]> dates){
-
 
         if (dates != null) {
             SimpleDateFormat format = new SimpleDateFormat("dd-MM-yyyy HH:mm");
@@ -111,38 +112,18 @@ public class UpcomingAppointments extends Fragment {
                     e.printStackTrace();
                 }
 
-                sortingMap.put(studyDate, name);
-                //listEntries.add(name + "\t\t" + date);
+                if(studyDate != null && name != null)
+                {
+                    sortingMap.put(studyDate, name);
                 getStudyIdByName.put(name, studyID);
+                }
             }
 
             for (Date key : sortingMap.keySet()) {
                 listEntries.add(sortingMap.get(key) + "\t\t" + key);
             }
+             arrivingDatesList.setAdapter(new CustomListViewAdapterAppointments(this.getContext(), this.getActivity(), navController, listEntries, getStudyIdByName));
 
-            ArrayAdapter arrayAdapter = new ArrayAdapter(getActivity(), android.R.layout.simple_list_item_1, listEntries);
-            arrivingDatesList.setAdapter(arrayAdapter);
-            arrivingDatesList.setOnItemClickListener(new android.widget.AdapterView.OnItemClickListener() {
-                @Override
-                public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                    String text = (String) arrivingDatesList.getItemAtPosition(position);
-                    String name = text.split("\t\t")[0];
-
-                    if (name != null) {
-                        String studyId = getStudyIdByName.get(name);
-                        //go to Study Detail View
-                        Bundle args = new Bundle();
-                        args.putString("studyId", studyId);
-                        if(PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyId)) {
-                            navController.navigate(R.id.action_homeFragment_to_studyCreatorFragment, args);
-                        }
-                        else
-                        {
-                            navController.navigate(R.id.action_homeFragment_to_studyFragment, args);
-                        }
-                    }
-                }
-            });
         }
     }
 

--- a/app/src/main/java/com/example/vpmanager/views/homeFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/homeFragment.java
@@ -67,6 +67,24 @@ public class homeFragment extends Fragment {
         tabLayout.addTab(tabLayout.newTab().setText("Persönliche Übersicht"));
         tabLayout.addTab(tabLayout.newTab().setText("Termine"));
 
+        tabLayout.addOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
+            @Override
+            public void onTabSelected(TabLayout.Tab tab) {
+                viewPager.setCurrentItem(tab.getPosition());
+                tabLayout.selectTab(tab);
+            }
+
+            @Override
+            public void onTabUnselected(TabLayout.Tab tab) {
+
+            }
+
+            @Override
+            public void onTabReselected(TabLayout.Tab tab) {
+
+            }
+        });
+
         ViewPagerAdapter viewPagerAdapter = new ViewPagerAdapter(getParentFragmentManager(), 0);//tabLayout.getTabCount());
         viewPagerAdapter.addFragment(personalAccountFragment, "Persönliche Übersicht");
         viewPagerAdapter.addFragment(appointments, "Termine");

--- a/app/src/main/java/com/example/vpmanager/views/mainActivity.java
+++ b/app/src/main/java/com/example/vpmanager/views/mainActivity.java
@@ -83,8 +83,7 @@ public class mainActivity extends AppCompatActivity implements DrawerController 
         //navController = Navigation.findNavController(this, R.id.nav_host_fragment_main);
 
         //Top level destinations are configured here. createStudyActivity and studyFragment should not be included!
-        appBarConfiguration = new AppBarConfiguration.Builder(R.id.homeFragment, R.id.findStudyFragment,
-                R.id.personalAccountFragment, R.id.ownStudyFragment).setDrawerLayout(drawerLayoutMain).build();
+        appBarConfiguration = new AppBarConfiguration.Builder(R.id.homeFragment, R.id.findStudyFragment, R.id.ownStudyFragment).setDrawerLayout(drawerLayoutMain).build();
 
         //handle Navigation item clicks
         //this works with no further action, if the menu and destination id’s match.

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="?android:windowBackground"
     android:layout_width="match_parent"
@@ -13,7 +13,10 @@
         android:layout_height="wrap_content"
         app:tabRippleColor="@color/green_light"
         app:tabIndicatorColor="@color/green_Main"
-        app:tabSelectedTextColor="@color/green_Main">
+        app:tabSelectedTextColor="@color/white"
+        app:tabTextColor="@color/white"
+        android:clickable="true"
+        android:focusable="true">
 
 
     </com.google.android.material.tabs.TabLayout>
@@ -26,4 +29,4 @@
         android:layout_height="match_parent"
         />
 
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home_dates.xml
+++ b/app/src/main/res/layout/fragment_home_dates.xml
@@ -11,27 +11,42 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="50dp"
+        android:layout_marginTop="10dp"
         android:orientation="vertical">
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="25dp"
-            android:layout_marginTop="30dp"
+            android:layout_marginTop="10dp"
             android:layout_marginEnd="25dp"
+            android:layout_marginBottom="10dp"
             android:text="Anstehende Termine"
             android:textSize="20sp"
             android:textStyle="bold" />
 
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginBottom="5dp"
+            android:layout_marginHorizontal="10dp"
+            android:elevation="10dp"
+            app:cardBackgroundColor="@color/cardview_light_background"
+            app:cardCornerRadius="10dp">
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="100"
+                android:fillViewport="true">
         <ListView
             android:id="@+id/listViewOwnArrivingStudyFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="20dp"
+            android:layout_marginTop="10dp"
             android:layout_weight="1"
             android:dividerHeight="2dp" />
-
+            </ScrollView>
+        </androidx.cardview.widget.CardView>
     </LinearLayout>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_personal_account.xml
+++ b/app/src/main/res/layout/fragment_personal_account.xml
@@ -14,7 +14,7 @@
         android:layout_height="150dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
-        android:layout_marginTop="50dp"
+        android:layout_marginTop="10dp"
         android:elevation="10dp"
         app:cardBackgroundColor="@color/cardview_light_background"
         app:cardCornerRadius="10dp">
@@ -67,7 +67,8 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="20dp"
-                    android:layout_gravity="center_vertical">
+                    android:layout_gravity="center_vertical"
+                    android:id="@+id/pa_completed_layout">
 
                     <!--View to display the yellow color icon-->
                     <View
@@ -194,16 +195,16 @@
             tools:ignore="RtlCompat" />
     </androidx.cardview.widget.CardView>
 
-
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
         android:layout_marginStart="25dp"
-        android:layout_marginTop="20dp"
         android:layout_marginEnd="25dp"
-        android:text="Studiendetails"
-        android:textSize="23sp"
+        android:text="Studien"
+        android:textSize="18sp"
         android:textStyle="bold" />
+
 
     <ScrollView
         android:layout_width="match_parent"
@@ -216,15 +217,24 @@
             android:layout_marginLeft="10dp"
             android:layout_marginRight="10dp"
             android:layout_marginTop="10dp"
+            android:layout_marginBottom="5dp"
             android:elevation="10dp"
+
             app:cardBackgroundColor="@color/cardview_light_background"
             app:cardCornerRadius="10dp">
 
+            <ListView
+                android:id="@+id/pa_fragment_listView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="10dp"
+                android:background="@color/cardview_light_background"/>
 
             <ExpandableListView
                 android:id="@+id/pa_fragment_expandableList"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:background="@color/cardview_light_background"/>
         </androidx.cardview.widget.CardView>
     </ScrollView>
 

--- a/app/src/main/res/layout/pa_listview_item.xml
+++ b/app/src/main/res/layout/pa_listview_item.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="55dp"
+        android:layout_marginBottom="5dp"
+        android:elevation="10dp"
+        app:cardBackgroundColor="@color/heatherred_hint"
+        app:cardCornerRadius="10dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="25dp"
+            android:layout_gravity="top"
+            android:layout_marginTop="5dp"
+            android:orientation="horizontal">
+        <TextView
+            android:id="@+id/listviewItemTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="25dp"
+            android:paddingHorizontal="?android:attr/expandableListPreferredChildPaddingLeft"
+            android:layout_gravity="top"
+            android:layout_marginBottom="5dp"
+            android:layout_marginTop="5dp"
+            android:text="TEST STUDIE"
+            android:textStyle="bold"/>
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                />
+            <androidx.cardview.widget.CardView
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:layout_marginBottom="5dp"
+                android:elevation="10dp"
+                app:cardCornerRadius="10dp"
+                android:layout_gravity="right"
+                android:layout_marginEnd="20dp">
+            <View
+                android:id="@+id/pa_listView_colorTag"
+                android:layout_width="25dp"
+                android:layout_height="match_parent"
+                android:background="@color/pieChartPlanned"/>
+            </androidx.cardview.widget.CardView>
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginTop="5dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_marginBottom="5dp"
+                android:layout_height="20dp"
+                android:layout_gravity="start"
+                android:text="VP-Stunden:"
+                android:paddingLeft="?android:attr/expandableListPreferredChildPaddingLeft" />
+
+            <TextView
+            android:id="@+id/pa_VP_view"
+            android:layout_width="wrap_content"
+            android:layout_marginBottom="5dp"
+            android:layout_height="20dp"
+            android:layout_gravity="start"
+            android:layout_marginEnd="20dp"
+            android:paddingHorizontal="5dp"
+            android:textStyle="bold"
+                android:text="1" />
+
+
+            <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="20dp"
+                android:layout_gravity="right"
+                android:gravity="right"
+                android:layout_marginBottom="5dp"
+                android:layout_marginEnd="5dp"
+                android:text="Termin:"
+                />
+            <TextView
+                android:id="@+id/pa_date_view"
+                android:layout_width="wrap_content"
+                android:layout_height="20dp"
+                android:layout_gravity="right"
+                android:gravity="right"
+                android:layout_marginBottom="5dp"
+                android:textStyle="italic"
+                android:text="22013213532523342"
+                android:paddingEnd="?android:attr/expandableListPreferredChildPaddingLeft"
+                />
+
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/layout/pa_upcoming_listview_item.xml
+++ b/app/src/main/res/layout/pa_upcoming_listview_item.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="55dp"
+        android:layout_marginBottom="5dp"
+        android:layout_marginHorizontal="10dp"
+        android:elevation="10dp"
+        app:cardBackgroundColor="@color/heatherred_hint"
+        app:cardCornerRadius="10dp">
+
+
+        <TextView
+            android:id="@+id/upcoming_listviewItemTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="25dp"
+            android:paddingHorizontal="?android:attr/expandableListPreferredChildPaddingLeft"
+            android:layout_gravity="top"
+            android:layout_marginBottom="5dp"
+            android:layout_marginTop="5dp"
+            android:text="TEST STUDIE"
+            android:textStyle="bold"/>
+
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginTop="5dp"
+            android:paddingHorizontal="?android:attr/expandableListPreferredChildPaddingLeft">
+
+
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="20dp"
+                android:layout_gravity="right"
+                android:gravity="right"
+                android:layout_marginBottom="5dp"
+                android:layout_marginEnd="5dp"
+                android:text="Termin:"
+                />
+            <TextView
+                android:id="@+id/pa_upcoming_date_view"
+                android:layout_width="wrap_content"
+                android:layout_height="20dp"
+                android:layout_gravity="right"
+                android:gravity="right"
+                android:layout_marginBottom="5dp"
+                android:textStyle="italic"
+                android:text="22013213532523342"
+                android:paddingEnd="?android:attr/expandableListPreferredChildPaddingLeft"
+                />
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/menu/navigation_drawer.xml
+++ b/app/src/main/res/menu/navigation_drawer.xml
@@ -7,8 +7,8 @@
 
         <item
             android:id="@+id/homeFragment"
-            android:icon="@drawable/ic_baseline_home_24"
-            android:title="Startseite" />
+            android:icon="@drawable/ic_baseline_person_24"
+            android:title="Persönliche Übersicht" />
         <item
             android:id="@+id/findStudyFragment"
             android:icon="@drawable/ic_baseline_search_24"
@@ -17,10 +17,6 @@
             android:id="@+id/createStudyActivity"
             android:icon="@drawable/ic_baseline_create_24"
             android:title="Studien erstellen" />
-        <item
-            android:id="@+id/personalAccountFragment"
-            android:icon="@drawable/ic_baseline_account_circle_24"
-            android:title="Meine Übersicht" />
         <item
             android:id="@+id/ownStudyFragment"
             android:icon="@drawable/ic_baseline_folder_24"

--- a/app/src/main/res/navigation/nav_graph_main.xml
+++ b/app/src/main/res/navigation/nav_graph_main.xml
@@ -35,7 +35,7 @@
     <fragment
         android:id="@+id/homeFragment"
         android:name="com.example.vpmanager.views.homeFragment"
-        android:label="Startseite"
+        android:label="VP Manager"
         tools:layout="@layout/fragment_home">
         <action
             android:id="@+id/action_homeFragment_to_findStudyFragment"
@@ -51,11 +51,6 @@
             android:id="@+id/action_homeFragment_to_createStudyActivity"
             app:destination="@id/createStudyActivity"
             app:popUpTo="@id/createStudyActivity"
-            app:popUpToInclusive="true" />
-        <action
-            android:id="@+id/action_homeFragment_to_personalAccountFragment"
-            app:destination="@id/personalAccountFragment"
-            app:popUpTo="@id/personalAccountFragment"
             app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_homeFragment_to_studyFragment"
@@ -89,22 +84,6 @@
         android:name="com.example.vpmanager.createStudy.createStudyActivity"
         android:label="Studien erstellen"
         tools:layout="@layout/activity_create_study" />
-    <fragment
-        android:id="@+id/personalAccountFragment"
-        android:name="com.example.vpmanager.views.personalAccountFragment"
-        android:label="Meine Übersicht"
-        tools:layout="@layout/fragment_personal_account">
-        <action
-            android:id="@+id/action_personalAccountFragment_to_studyFragment"
-            app:destination="@id/studyFragment"
-            app:popUpTo="@id/studyFragment"
-            app:popUpToInclusive="true" />
-        <action
-            android:id="@+id/action_personalAccountFragment_to_studyCreatorFragment"
-            app:destination="@id/studyCreatorFragment"
-            app:popUpTo="@id/studyCreatorFragment"
-            app:popUpToInclusive="true" />
-    </fragment>
     <fragment
         android:id="@+id/ownStudyFragment"
         android:name="com.example.vpmanager.views.ownStudyFragment"


### PR DESCRIPTION
Closes #137 

Finalizing transportation of personalAccountFragment to a tab in homeFragment. 
Removing the personalAccountFragment from navigation graph, since all navigations are now directed over the homefragment.
Removing personal Account from Navigation drawer and renaming the previous "Startseite" to "Persönliche Übersicht" since the personal account is now found there.

A minor redesign was conducted for the Listviews of the personalAccountFragment in preparation of issue #131 