### PR TITLE
Bugfix Navigation switch between studyFragment und studyCreatorFragment

### DIFF
--- a/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
+++ b/app/src/main/java/com/example/vpmanager/PA_ExpandableListDataPump.java
@@ -4,9 +4,11 @@ import static android.content.ContentValues.TAG;
 import static com.example.vpmanager.views.mainActivity.uniqueID;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.navigation.NavController;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -404,26 +406,46 @@ public class PA_ExpandableListDataPump extends Activity {
     //Parameters: identifier of user, identifier of study
     //Return Values
     //checks if a given user is the creator of a given study
-    public static boolean navigateToStudyCreatorFragment(String currentUserId, String currentStudyId) {
+    public static void navigateToStudyCreatorFragment(String currentUserId, String currentStudyId, String source, NavController navController) {
 
-        if (DB_STUDIES_LIST.size() <= 0) {
-            Thread t = new Thread(() -> getAllStudies(() -> {
-            }));
-            t.start();
+        db = FirebaseFirestore.getInstance();
+        studiesRef = db.collection("studies");
+        studiesRef.whereEqualTo("id", currentStudyId).get()
+                .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                    @Override
+                    public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                        if (task.isSuccessful()) {
+                            Bundle args = new Bundle();
+                            args.putString("studyId", currentStudyId);
 
-            try {
-                t.join();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }
-        for (Map<String, Object> map : DB_STUDIES_LIST) {
-            if (Objects.requireNonNull(map.get("creator")).toString().equals(currentUserId) &&
-                    Objects.requireNonNull(map.get("id")).toString().equals(currentStudyId)) {
-                return true;
-            }
-        }
-        return false;
+                            for (QueryDocumentSnapshot document : task.getResult()) {
+                                if (Objects.requireNonNull(document.getString("creator")).equals(currentUserId)) {
+
+                                    if (source.equals("HomeFragment"))
+                                        navController.navigate(R.id.action_homeFragment_to_studyCreatorFragment, args);
+                                    if (source.equals("FindStudyFragment"))
+                                        navController.navigate(R.id.action_findStudyFragment_to_studyCreatorFragment, args);
+                                    if (source.equals("UpcomingAppointmentsFragment"))
+                                        navController.navigate(R.id.action_upcomingAppointmentsFragment_to_studyCreatorFragment, args);
+                                    if (source.equals("OwnStudyFragment"))
+                                        navController.navigate(R.id.action_ownStudyFragment_to_studyCreatorFragment, args);
+
+                                } else {
+
+                                    if (source.equals("HomeFragment"))
+                                        navController.navigate(R.id.action_homeFragment_to_studyFragment, args);
+                                    if (source.equals("FindStudyFragment"))
+                                        navController.navigate(R.id.action_findStudyFragment_to_studyFragment, args);
+                                    if (source.equals("UpcomingAppointmentsFragment"))
+                                        navController.navigate(R.id.action_upcomingAppointmentsFragment_to_studyFragment, args);
+                                    if (source.equals("OwnStudyFragment"))
+                                        navController.navigate(R.id.action_ownStudyFragment_to_studyFragment, args);
+
+                                }
+                            }
+                        }
+                    }
+                });
     }
 
     //Parameters

--- a/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapter.java
+++ b/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapter.java
@@ -139,13 +139,8 @@ public class CustomListViewAdapter extends BaseAdapter {
                     Bundle args = new Bundle();
                     StudyObjectPa study = objects.get(position);
                     args.putString("studyId", study.getStudyId());
-                    if (PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, study.getStudyId())) {
-                        navController.navigate(R.id.action_ownStudyFragment_to_studyCreatorFragment, args);
-                    } else {
-                        navController.navigate(R.id.action_ownStudyFragment_to_studyFragment, args);
-                    }
-                }
-            });
+                    PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, study.getStudyId(), "OwnStudyFragment", navController);
+                }});
         }
         return convertView;
     }

--- a/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapterAppointments.java
+++ b/app/src/main/java/com/example/vpmanager/adapter/CustomListViewAdapterAppointments.java
@@ -3,7 +3,6 @@ package com.example.vpmanager.adapter;
 import static com.example.vpmanager.views.mainActivity.uniqueID;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -95,41 +94,14 @@ public class CustomListViewAdapterAppointments extends BaseAdapter {
 
             holder.titleTextView = titleView;
             holder.dateTextView = dateView;
-            switch(sourceFragment) {
-                case "HomeFragment":
 
-                    convertView.setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            Bundle args = new Bundle();
-                            StudyObjectPa study = objects.get(position);
-                            args.putString("studyId", study.getStudyId());
-                            if (PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, study.getStudyId())) {
-                                navController.navigate(R.id.action_homeFragment_to_studyCreatorFragment, args);
-                            } else {
-                                navController.navigate(R.id.action_homeFragment_to_studyFragment, args);
-                            }
-                        }
-                    });
-                    break;
-                case "UpcomingAppointmentsFragment":
-
-                    convertView.setOnClickListener(new View.OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            Bundle args = new Bundle();
-                            StudyObjectPa study = objects.get(position);
-                            args.putString("studyId", study.getStudyId());
-                            if (PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, study.getStudyId())) {
-                                navController.navigate(R.id.action_upcomingAppointmentsFragment_to_studyCreatorFragment, args);
-                            } else {
-                                navController.navigate(R.id.action_upcomingAppointmentsFragment_to_studyFragment, args);
-                            }
-                        }
-                    });
-                    break;
-
-            }
+            convertView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    StudyObjectPa study = objects.get(position);
+                    PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, study.getStudyId(), sourceFragment, navController);
+                }
+            });
         }
         return convertView;
     }

--- a/app/src/main/java/com/example/vpmanager/views/FindStudyFragment.java
+++ b/app/src/main/java/com/example/vpmanager/views/FindStudyFragment.java
@@ -79,13 +79,6 @@ public class FindStudyFragment extends Fragment implements StudyListAdapter.OnSt
     //Navigates to the more detailed view of a study
     @Override
     public void onStudyClick(String studyId) {
-        Bundle args = new Bundle();
-        Log.d("FindStudyFragment", "onStudyClick - studyId:" + studyId);
-        args.putString("studyId", studyId);
-        if (PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyId)) {
-            navController.navigate(R.id.action_findStudyFragment_to_studyCreatorFragment, args);
-        } else {
-            navController.navigate(R.id.action_findStudyFragment_to_studyFragment, args);
-        }
+        PA_ExpandableListDataPump.navigateToStudyCreatorFragment(uniqueID, studyId, "FindStudyFragment", navController);
     }
 }


### PR DESCRIPTION
close #235  

Because:
- error when navigating to selfcreated studies. Due to async database calls, creators sometimes saw study as a participant

restructured navigation calls to a single method in a central class. Navigation is conducted on successful database call