### PR TITLE
Removed double icons in find study

### DIFF
--- a/app/src/main/java/com/example/vpmanager/adapter/StudyListAdapter.java
+++ b/app/src/main/java/com/example/vpmanager/adapter/StudyListAdapter.java
@@ -117,9 +117,11 @@ public class StudyListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         public void setIcon(String type) {
             if (type.equals("Präsenz")) {
                 locationIcon.setVisibility(View.VISIBLE);
+                remoteIcon.setVisibility(View.INVISIBLE);
                 locationIcon.setAnimation(animation);
             } else {
                 remoteIcon.setVisibility(View.VISIBLE);
+                locationIcon.setVisibility(View.INVISIBLE);
                 remoteIcon.setAnimation(animation);
             }
         }


### PR DESCRIPTION
close #254 
The cards in find study showed two icons at the same time, which is now fixed.