### PR TITLE
Disabled removing booked appointments

### DIFF
--- a/app/src/main/java/com/example/vpmanager/adapter/EditSwipeableDatesAdapter.java
+++ b/app/src/main/java/com/example/vpmanager/adapter/EditSwipeableDatesAdapter.java
@@ -81,10 +81,20 @@ public class EditSwipeableDatesAdapter extends RecyclerView.Adapter<RecyclerView
     //Deletes associated date item
     public void deleteItem(int position) {
         mRecentlyDeletedDate = editDatesList.get(position);
-        mRecentlyDeletedDatePosition = position;
-        editDatesList.remove(position);
-        notifyItemRemoved(position);
-        showUndoSnackBar();
+        if(mRecentlyDeletedDate.getSelected() && mRecentlyDeletedDate.getUserId() != null)
+        {
+            View view = mFragmentView.findViewById(R.id.edit_study_dates_layout);
+            Snackbar snackbar = Snackbar.make(view, R.string.removeAppointmentnotPossible,
+                    Snackbar.LENGTH_LONG);
+            snackbar.show();
+            notifyDataSetChanged();
+        }
+        else {
+            mRecentlyDeletedDatePosition = position;
+            editDatesList.remove(position);
+            notifyItemRemoved(position);
+            showUndoSnackBar();
+        }
     }
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,6 +256,7 @@
     <string name="changeStudyStateTitleOpen">Studie wieder öffnen</string>
     <string name="saveStudy">Studie speichern</string>
     <string name="removeAppointmentAlert">1 Termin gelöscht</string>
+    <string name="removeAppointmentnotPossible">Belegte Termine können nicht entfernt werden.</string>
     <string name="cancelAction">Rückgängig</string>
 
 


### PR DESCRIPTION
close #209

Creators can not delete appointments that were selected by users when they edit a study.

Co-Author @Mutigo 